### PR TITLE
Add zero-service SQLite backend for cross-process rate limiting on one host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --all-extras --group dev
-      - run: uv run pytest tests/integration -v --redis-url redis://localhost:6379
+      - run: uv run pytest tests/integration tests/multiprocess -v --redis-url redis://localhost:6379/13
+        env:
+          TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE: "2"
 
   test-min-deps:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,9 @@ jobs:
         with:
           python-version: "3.13"
       - run: uv sync --all-extras --group dev
-      - run: uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy --redis-url redis://localhost:6379
+      - run: uv run pytest --cov --cov-report=xml --junitxml=junit.xml -o junit_family=legacy --redis-url redis://localhost:6379/13
+        env:
+          TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE: "2"
       - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ changes and upgrade steps are recorded in its entry below.
 
 ## Unreleased
 
+- Adds stdlib-only synchronous and asynchronous SQLite backends for persistent,
+  multi-process rate-limit coordination on one host without a separate server.
+  Use memory for one process, SQLite for multiple processes on one local
+  filesystem, and Redis when a budget must span machines. SQLite state uses WAL
+  transactions, durable acquire/refund bookkeeping, expiring runtime
+  overrides, and configurable contention and TTL bounds; network filesystems
+  are outside its supported scope.
+- Adds spawn-based multi-process coverage for SQLite and Redis shared-budget
+  enforcement, cross-process refunds, crash-orphan linear refill, late-refund
+  failure, contention accounting, and fresh-interpreter persistence, plus a
+  SQLite try-acquire writer-contention regression.
+- Widens the diagnostic backend type additively with the `"sqlite"` literal.
+  SQLite `diagnose()` output now uses a first-class structured health section
+  with exact acquire-marker and refund-tombstone counts; `snapshot_state()`
+  exposes the same local best-effort durable-count estimates as Redis.
 - Adds a runnable Anthropic Messages example with independent RPM, ITPM, and
   OTPM buckets; server-side pre-flight token counting; prompt-cache prewarming;
   cache-aware input refunds; observed-p99 output reservations; raw rate-limit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ changes and upgrade steps are recorded in its entry below.
 
 - Adds stdlib-only synchronous and asynchronous SQLite backends for persistent,
   multi-process rate-limit coordination on one host without a separate server.
+  The four new public exports are `SqliteBackend`, `SqliteBackendBuilder`,
+  `SyncSqliteBackend`, and `SyncSqliteBackendBuilder`.
   Use memory for one process, SQLite for multiple processes on one local
   filesystem, and Redis when a budget must span machines. SQLite state uses WAL
   transactions, durable acquire/refund bookkeeping, expiring runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Notable changes for token-throttle releases. Each major version's breaking
 changes and upgrade steps are recorded in its entry below.
 
-## Unreleased
+## 10.1.0 - 2026-08-26
 
 - Adds stdlib-only synchronous and asynchronous SQLite backends for persistent,
   multi-process rate-limit coordination on one host without a separate server.

--- a/README.md
+++ b/README.md
@@ -210,16 +210,16 @@ asyncio.run(main())
 
 **The solution:** Reserve before you call, refund after. Actual usage is tracked, not estimated maximums.
 
-Why not a semaphore or a generic rate limiter? Those cap request count or assume a fixed worst-case token cost and never return unused capacity, so you either overprovision (crawl at half throughput) or underprovision (429s). token-throttle reserves your declared maximum, then refunds the delta from actual usage — across multiple simultaneous resources (requests, tokens, input/output), coordinated across processes via Redis.
+Why not a semaphore or a generic rate limiter? Those cap request count or assume a fixed worst-case token cost and never return unused capacity, so you either overprovision (crawl at half throughput) or underprovision (429s). token-throttle reserves your declared maximum, then refunds the delta from actual usage — across multiple simultaneous resources (requests, tokens, input/output), coordinated across processes via SQLite on one host or Redis across machines.
 
 | Feature | Details |
 |---------|---------|
 | **Multi-resource limits** | Limit requests, tokens, input/output tokens — simultaneously, each with its own quota |
 | **Multiple time windows** | e.g., 1,000 req/min AND 10,000 req/day on the same resource |
 | **Reserve & refund** | Reserve max expected usage upfront, refund the difference after the call completes |
-| **Distributed** | Redis backend with atomic locks — safe across workers and processes |
+| **Shared budgets** | SQLite coordinates processes on one host; Redis coordinates services across machines |
 | **Per-model quotas** | Different limits per model via `model_family`; the built-in OpenAI helper auto-groups date-suffixed variants (e.g. gpt-4o-20241203 → gpt-4o) |
-| **Pluggable** | Bring your own backend (ships with Redis and in-memory). Sync and async APIs |
+| **Pluggable** | Bring your own backend (ships with memory, SQLite, and Redis). Sync and async APIs |
 | **Observability** | Callbacks for wait-start, wait-end, consume, refund, and missing-state events |
 
 ## How it works
@@ -305,18 +305,41 @@ See [docs/configuration.md](docs/configuration.md#per-model-configuration).
 
 ### Backends
 
+Choose the backend from the scope of the budget:
+
+1. **One process:** use memory. SQLite and Redis also work here; SQLite adds
+   persistence across ordinary process restarts.
+2. **Multiple processes on one host, with no server:** use SQLite with one
+   shared database path and key prefix.
+3. **Multiple machines:** use Redis with one shared deployment-scoped key
+   prefix.
+
+**SQLite needs no install extra or external service; it uses Python's stdlib
+`sqlite3`.** It is limited to one host and a local filesystem — never NFS or
+another network filesystem. See the [SQLite backend guide](docs/sqlite-backend.md)
+for its clock, persistence, TTL, contention, and crash contracts.
+
 ```python
 # (fragment — see Memory quickstart for standalone context)
-# Distributed (multiple workers/processes)
+# Multiple machines
 from token_throttle import RedisBackendBuilder
 backend = RedisBackendBuilder(redis_client, key_prefix="my-service-prod")
 
-# Single process (no Redis needed)
+# Multiple processes on one host; stdlib only
+from token_throttle import SqliteBackendBuilder
+backend = SqliteBackendBuilder(
+    "/var/lib/my-service/rate-limits.sqlite3",
+    key_prefix="my-service-prod",
+)
+
+# One process
 from token_throttle import MemoryBackendBuilder
 backend = MemoryBackendBuilder()
 ```
 
-Both backends are available in sync (`SyncRedisBackendBuilder`, `SyncMemoryBackendBuilder`) and async variants.
+All three backends have async builders shown above and sync variants:
+`SyncMemoryBackendBuilder`, `SyncSqliteBackendBuilder`, and
+`SyncRedisBackendBuilder`.
 
 Custom backends implement `RateLimiterBackend` or `SyncRateLimiterBackend`. See
 [docs/custom-backends.md](docs/custom-backends.md) for the protocol contract and
@@ -354,11 +377,13 @@ await limiter.set_max_capacity(
 )
 ```
 
-For Redis backends the new limit is written to Redis, so all processes
-sharing the same Redis see the change within ~1 second.
+For SQLite and Redis backends the new limit is written to shared storage, so
+cooperating processes see the change on their next backend operation (within
+about one second for a waiting SQLite process). SQLite overrides expire after
+`override_ttl_seconds` unless they are set again.
 
-Runtime-override semantics — Redis propagation, remove-and-readd behavior, and
-ordering against concurrent config rotations — are covered in
+Runtime-override semantics — cross-process propagation, expiration,
+remove-and-readd behavior, and ordering against config rotations — are covered in
 [docs/configuration.md](docs/configuration.md#dynamic-rate-limits).
 
 ### Timeout
@@ -480,6 +505,7 @@ are covered in [docs/operations.md](docs/operations.md#concurrency-model).
 
 - [docs/api.md](docs/api.md) — public constants and type aliases
 - [docs/configuration.md](docs/configuration.md) — per-model caps, unlimited configs, custom usage counters, dynamic limits
+- [docs/sqlite-backend.md](docs/sqlite-backend.md) — single-host persistence, scope, clock, TTL, contention, crash behavior, troubleshooting
 - [docs/operations.md](docs/operations.md) — reservation durability, concurrency model, Redis topology, multi-tenant isolation, capacity planning, application-facing errors
 - [docs/observability.md](docs/observability.md) — logging, lifecycle events, health snapshots, `diagnose()` diagnostics, PII surface
 - [docs/custom-backends.md](docs/custom-backends.md) — implement your own backend

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,10 +112,19 @@ await limiter.set_max_capacity(
 )
 ```
 
-For Redis backends the new limit is written to Redis, so all processes
-sharing the same Redis see the change within ~1 second. This persisted Redis
-value is an explicit runtime override; static quota changes from your config do
-not rewrite it automatically.
+For Redis backends the new limit is written to Redis, so all processes sharing
+the same Redis see the change within ~1 second. For SQLite backends it is
+written to the shared database; other processes see it on their next operation,
+with an approximately one-second upper polling interval for capacity waiters.
+In both cases the shared value is an explicit runtime override, not a static
+config edit.
+
+SQLite runtime overrides expire after `override_ttl_seconds`, which defaults to
+`bucket_ttl_seconds`; ordinary bucket activity does not extend that fixed
+lifetime. Once an override expires, every process falls back to its own
+process-local configured quota. SQLite does not distribute `PerModelConfig`, so
+deploy the same static quotas to every process sharing a database and prefix.
+Calling `set_max_capacity()` again replaces the override and starts a new TTL.
 
 If a callable config removes a bucket and later re-adds it, the re-added
 bucket starts from the static quota in the current config. Runtime overrides
@@ -127,4 +136,7 @@ and let the limiter rebuild on the next acquire/refund. `set_max_capacity()` is
 an explicit runtime override, not a config edit. Config rotations concurrent
 with `set_max_capacity()` are ordered by whichever backend update completes
 last; a later config rebuild resolves back to the static quota unless you
-reapply the override.
+reapply the override. For SQLite, applying a changed static quota clears the
+shared override for that bucket, so coordinate config rollout and override
+writers across processes. See the [SQLite backend guide](sqlite-backend.md#runtime-overrides-and-configuration)
+for the persistence and expiry details.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -13,24 +13,26 @@ lifecycle event fields, callback timeouts, and the full PII surface.
 Every `RateLimiter` and `SyncRateLimiter` logs the `token_throttle` package
 version at `INFO` during initialization. Existing callback loggers use the
 `token_throttle` logger by default through `create_logging_callbacks()` and
-`create_sync_logging_callbacks()`. Redis internals also emit structured
+`create_sync_logging_callbacks()`. Redis and SQLite internals also emit structured
 `DEBUG` records under:
 
 - `token_throttle.acquire` for acquire marker reads/writes/deletes.
 - `token_throttle.refund` for refund marker GET/DEL and refund-dedup writes.
-- `token_throttle.lock` for Redis lock acquire, release, and extension events.
+- `token_throttle.lock` for Redis lock acquire, release, and extension events;
+  SQLite has no event family here because it uses the database writer lock.
 
-Redis debug records include a `token_throttle_event` logging attribute with
+Redis and SQLite debug records include a `token_throttle_event` logging attribute with
 `event_type`, `reservation_id`, `bucket_id`, and operation-specific fields. For
 example, a stdlib handler can read `record.token_throttle_event` and turn it
 into counters or spans.
 
 ## Health snapshot
 
-For Redis backends, marker and refund-dedup counts from `snapshot_state()` are
-best-effort local estimates from limiter bookkeeping, not a cross-process Redis
-inventory. The snapshot intentionally omits Redis URLs, credentials, and Redis
-key prefixes.
+For Redis and SQLite backends, `marker_count_estimate` and
+`refund_dedup_count_estimate` from `snapshot_state()` are best-effort local
+estimates from limiter bookkeeping, not a cross-process datastore inventory.
+The snapshot intentionally omits Redis URLs, credentials, SQLite paths, and
+backend key prefixes.
 
 ## Diagnostics (`diagnose()`)
 
@@ -44,9 +46,10 @@ It reports, per model family and bucket: current and effective capacity, the
 configured limit, and any active runtime override with its source (`limiter`,
 `backend`, or `both`); in-flight/pending/delivery-cleanup reservation counts
 grouped by family and metric; current acquire waiters and each one's primary
-capacity bottleneck; backend health for memory, Redis, and custom backends;
-and a severity-sorted `issues` list covering best-effort degradation or
-introspection failures.
+capacity bottleneck; backend health for memory, Redis, SQLite, and custom
+backends; and a severity-sorted `issues` list covering best-effort degradation
+or introspection failures. SQLite health includes exact namespace-scoped
+acquire-marker and refund-tombstone row counts.
 
 Reach for `diagnose()` when investigating a stuck or slow acquire, unexplained
 capacity drift, a suspected override mismatch between limiter and backend
@@ -128,13 +131,13 @@ threads and never block interpreter exit.
 
 - User-controlled fields: request `model`, lifecycle `model_alias`, optional
   `request_id`, custom usage metric names, `model_family` when supplied by your
-  config, and Redis `key_prefix` configured by the application.
+  config, and backend `key_prefix` configured by the application.
 - Potentially sensitive fields: `request_id` if it contains customer or trace
   identifiers; `model_alias` and `model_family` if your naming scheme embeds
   tenant, deployment, or account data; usage values if request size is
   sensitive in your environment.
 - Not logged or returned by `snapshot_state()`: Redis URLs, credentials, Redis
-  client objects, and plaintext key prefixes.
+  client objects, SQLite database paths, and plaintext key prefixes.
 - Never included by token-throttle observability surfaces: prompt text,
   messages, responses, API keys, or request payload bodies. A custom
   `usage_counter` or your own callback code may log those separately, so audit

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -195,7 +195,13 @@ Redis refunds also write a cross-process idempotency key:
 builders or Redis OpenAI factories. Memory backends keep only process-local
 refund dedup state and cannot safely refund reservations after a cold restart.
 
-## Per-bucket locking and contention
+## Shared-storage locking and contention
+
+Redis serializes each bucket with a distributed lock. SQLite instead serializes
+transactions through the database-wide writer lock and uses
+`busy_timeout_ms` as the analogue of Redis's
+`lock_blocking_timeout_seconds`. Both backends keep multi-bucket writes atomic;
+their tuning and throughput ceilings differ.
 
 The Redis backend serializes every mutation of a given bucket through a
 short-lived per-bucket lock, so concurrent workers never race on the same

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,6 +7,8 @@ connection/TTL sizing, and capacity planning for high-RPS fleets.
 Start with the [README](../README.md) for installation, the mental model, and
 quickstarts. Reach for this guide once you are deploying on Redis and need to
 reason about durability, scaling ceilings, and resource budgets.
+For single-host, multi-process deployments, use the dedicated
+[SQLite backend guide](sqlite-backend.md).
 
 ## Reservation lifecycle and durability
 
@@ -227,17 +229,24 @@ contention depends on the call:
   case the write is aborted and makes no change), they raise
   `BackendLockContentionError`.
 
+### Backend contention retry contract
+
 `BackendLockContentionError` is exported from the top-level `token_throttle`
-package. When you see it, the operation did not modify state and is safe to
-retry. Seeing it repeatedly means a bucket is genuinely hot; the durable fixes
-are to reduce concurrency on that bucket, spread traffic across more model
-families/windows, provision Redis CPU headroom, or raise
-`lock_blocking_timeout_seconds` so attempts wait longer before giving up. The
-memory backends have no Redis lock and never raise `BackendLockContentionError`.
+package and is shared by the Redis and SQLite backends. When you see it, the
+operation did not modify state and is safe to retry.
+
+For Redis, repeated errors mean a bucket is genuinely hot or its lock deadline
+is too short. Reduce concurrency on that bucket, spread traffic across more
+model families/windows, provision Redis CPU headroom, or raise
+`lock_blocking_timeout_seconds`. SQLite raises the same exception when a
+non-waiting write cannot obtain the database writer lock within
+`busy_timeout_ms`; see [Write contention and try-acquire behavior](sqlite-backend.md#write-contention-and-try-acquire-behavior).
+Memory backends have no shared-storage lock and do not raise this exception.
 
 ## Application-facing errors
 
-Beyond `BackendLockContentionError` (lock contention, covered above) and
+Beyond `BackendLockContentionError` (backend write/lock contention, covered
+above) and
 `TimeoutError` (capacity-wait deadline exceeded, see the
 [README Timeout section](../README.md#timeout)), these are the
 token-throttle-specific exceptions an application should expect at the

--- a/docs/sqlite-backend.md
+++ b/docs/sqlite-backend.md
@@ -34,10 +34,10 @@ filesystem:
   same `key_prefix`. The builder resolves the path with `realpath`; prefer one
   absolute path rather than relying on different processes' working
   directories.
-- Do not place the database on NFS, SMB, a distributed filesystem, or any
-  other network-mounted filesystem. SQLite WAL locking is not the contract for
-  cross-host coordination, and token-throttle does not try to detect network
-  mounts.
+- Do not place the database on NFS, SMB, overlayfs, a distributed filesystem,
+  or any other network/overlay-mounted filesystem. Those filesystems are
+  unsupported for this backend and are the most likely way to break its WAL
+  locking assumptions. token-throttle does not try to detect the mount type.
 - Containers work only when they run on the same host, share the same local
   volume, and share the host's clock. A container-local path that is not
   mounted into every cooperating container creates separate budgets.
@@ -107,6 +107,14 @@ still enforced when a specific marker or tombstone is addressed.
 | `refund_dedup_ttl_seconds` | 604800 (7 days) | How long a completed refund remains recognizable as a duplicate. |
 | `max_reservation_lifetime_seconds` | Derived | Maximum age at which an acquire marker remains refundable. When omitted, it is just below half of the shorter bucket/refund TTL. |
 | `override_ttl_seconds` | `bucket_ttl_seconds` | Fixed lifetime of a shared `set_max_capacity()` override, measured from the call that writes it. Ordinary bucket activity does not extend it. |
+| `busy_timeout_ms` | 5000 | Maximum SQLite writer-lock wait for ordinary operations. A finite acquire deadline can reduce it, and a try-acquire uses zero. |
+| `prune_batch_size` | 256 | Maximum expired rows pruned from each durable table by one cleanup pass. |
+
+All three SQLite TTL options require a positive, finite integer number of
+seconds (at most `2**31 - 1`). `None` is not a supported "never expire" value,
+including for bucket or refund-dedup state. This release intentionally keeps
+all durable bookkeeping bounded; choose a sufficiently long finite TTL when
+you need a long idle or refund window.
 
 The builder enforces both safety inequalities:
 
@@ -183,6 +191,19 @@ If write-lock waits are common, tail latency matters, or traffic is growing
 beyond this envelope, move the shared budget to Redis. Do not split one logical
 budget across multiple SQLite files to gain throughput; that creates
 independent limits.
+
+## Observability
+
+For SQLite, `snapshot_state()` includes `marker_count_estimate` and
+`refund_dedup_count_estimate`. They are cheap, process-local estimates from the
+limiter's own bookkeeping, not database-wide counts. This keeps routine health
+polling free of SQLite I/O.
+
+Use `diagnose()` when you need backend state. Its first-class SQLite health
+section reports exact acquire-marker and refund-tombstone row counts for the
+database namespace, along with per-bucket capacity and active override data.
+Because `diagnose()` reads SQLite, it can wait up to `busy_timeout_ms` for a
+writer and can degrade to a warning if introspection cannot complete.
 
 ## Troubleshooting
 

--- a/docs/sqlite-backend.md
+++ b/docs/sqlite-backend.md
@@ -1,0 +1,215 @@
+# SQLite backend guide
+
+The SQLite backend shares one rate-limit budget between processes on a single
+host and keeps bucket state across ordinary process restarts. It is a good fit
+for CLI tools, cron jobs, local worker pools, and small services that need more
+than process-local memory but do not want to operate Redis.
+
+SQLite support needs no token-throttle install extra and no external service.
+It uses Python's standard-library `sqlite3` module. Both `SqliteBackendBuilder`
+and `SyncSqliteBackendBuilder` implement the same accounting contract as the
+memory and Redis backends, including atomic multi-bucket acquisition, durable
+acquire markers, and refund-deduplication tombstones.
+
+```python
+# (fragment — use this builder with the README async quickstart)
+from token_throttle import SqliteBackendBuilder
+
+backend = SqliteBackendBuilder(
+    "/var/lib/my-service/rate-limits.sqlite3",
+    key_prefix="my-service-prod",
+)
+```
+
+Use `SyncSqliteBackendBuilder` with `SyncRateLimiter`. Close the limiter when it
+shuts down so its SQLite connection and, for the async backend, worker thread
+are released.
+
+## Scope boundary
+
+SQLite coordination is deliberately limited to one host and one local
+filesystem:
+
+- Every cooperating process must use the same stable database path and the
+  same `key_prefix`. The builder resolves the path with `realpath`; prefer one
+  absolute path rather than relying on different processes' working
+  directories.
+- Do not place the database on NFS, SMB, a distributed filesystem, or any
+  other network-mounted filesystem. SQLite WAL locking is not the contract for
+  cross-host coordination, and token-throttle does not try to detect network
+  mounts.
+- Containers work only when they run on the same host, share the same local
+  volume, and share the host's clock. A container-local path that is not
+  mounted into every cooperating container creates separate budgets.
+- SQLite does not coordinate multiple machines. Use the
+  [Redis backend](operations.md#redis-topology-support) when callers on
+  different hosts must share a budget.
+
+The `key_prefix` isolates unrelated budgets inside one database file. It is a
+namespace boundary, not a CPU or disk-I/O isolation boundary; use separate
+database files when independent workloads should not contend on the same
+SQLite writer lock.
+
+## Clock authority
+
+The host wall clock is authoritative. Every process on the host reads the same
+kernel clock, so there is no separate server-clock protocol.
+
+- If the clock moves backward, refill clamps elapsed time to zero and emits a
+  `RuntimeWarning` plus a structured warning with the affected model family and
+  metric. A stored timestamp more than one second in the future is repaired in
+  the same transaction while preserving the stored capacity, so it cannot pin
+  a drained persistent bucket indefinitely.
+- If the clock moves forward, the bucket refills for the apparent elapsed time,
+  capped at its maximum capacity. There is no forward-jump detection rail.
+- Time spent suspended counts as elapsed wall time, so a laptop or VM may
+  resume with refilled buckets.
+
+This contract does not promise agreement between different hosts, time
+namespaces, or a database opened from machines with different clocks. Keep NTP
+or the host's equivalent time synchronization healthy.
+
+## Persistence and path identity
+
+Bucket capacity, refill timestamps, active runtime overrides, acquire markers,
+and refund tombstones live in the database. SQLite uses WAL mode and atomic
+transactions, so incomplete process transactions are rolled back and committed
+state is available when a new process opens the same path and prefix.
+
+Static `PerModelConfig` quota definitions do not live in SQLite. Every process
+must deploy compatible configuration for each shared `model_family`; the
+database is coordination state, not configuration distribution. A new process
+combines its own configured quotas with the persisted capacity and any active
+runtime override.
+
+`CapacityReservation` remains trusted in-process state, not a portable durable
+credential. Do not serialize a reservation and present it to a newly created
+limiter after a restart. Persistence protects shared accounting and duplicate
+refund handling between live cooperating processes; it does not change the
+[reservation trust boundary](operations.md#reservation-lifecycle-and-durability).
+
+The connection uses `synchronous=NORMAL`. SQLite preserves database consistency
+after a process or operating-system crash, but the most recently committed
+transactions can be lost after abrupt power or storage failure. If losing the
+latest accounting update is unacceptable, use infrastructure and a backend
+whose durability settings match that requirement.
+
+## TTL and reservation-lifetime knobs
+
+SQLite prunes expired rows lazily during write operations, in bounded batches
+controlled by `prune_batch_size` (default `256`). There is no cleanup daemon, so
+an expired row can remain physically present until later activity. Expiry is
+still enforced when a specific marker or tombstone is addressed.
+
+| Builder option | Default | Contract |
+| --- | ---: | --- |
+| `bucket_ttl_seconds` | 604800 (7 days) | Inactivity lifetime for bucket rows. It must be at least the longest configured quota window. After expiry the next use is a fresh bucket; by the validated window bound it has already had enough time to refill fully. |
+| `refund_dedup_ttl_seconds` | 604800 (7 days) | How long a completed refund remains recognizable as a duplicate. |
+| `max_reservation_lifetime_seconds` | Derived | Maximum age at which an acquire marker remains refundable. When omitted, it is just below half of the shorter bucket/refund TTL. |
+| `override_ttl_seconds` | `bucket_ttl_seconds` | Fixed lifetime of a shared `set_max_capacity()` override, measured from the call that writes it. Ordinary bucket activity does not extend it. |
+
+The builder enforces both safety inequalities:
+
+```text
+bucket_ttl_seconds > max_reservation_lifetime_seconds * 2
+refund_dedup_ttl_seconds > max_reservation_lifetime_seconds * 2
+```
+
+Choose the reservation lifetime from the longest real request latency, retry
+delay, and shutdown-drain period you intend to support. Then make both durable
+TTLs more than twice that lifetime. Shorter values reduce persistent marker and
+tombstone rows but also shorten the valid late-refund window.
+
+## Runtime overrides and configuration
+
+`set_max_capacity()` writes an expiring override into SQLite after anchoring
+capacity accrued at the previous rate. Other processes using the same database
+and prefix observe it on their next backend operation; a process already
+waiting for capacity polls shared state at least about once per second.
+
+The override is a shared control layer, while static configuration remains
+process-local. When `override_ttl_seconds` elapses, each process returns to its
+own configured quota on its next operation. Calling `set_max_capacity()` again
+replaces the value and starts a new TTL. Keep static configuration consistent
+across the fleet so override expiry cannot reveal conflicting base limits.
+
+A static quota change detected by a process clears the shared override for that
+bucket and applies the new configured limit locally. Removing a metric and
+later re-adding it also drops its prior runtime override. Coordinate config
+rollouts with override writers, and reapply an override after the rollout when
+that is the intended final state. The complete limiter-level contract is in
+[Dynamic rate limits](configuration.md#dynamic-rate-limits).
+
+## Write contention and try-acquire behavior
+
+SQLite permits one writer at a time. `busy_timeout_ms` (default `5000`) lets a
+normal write wait through short lock contention. Non-waiting operations such as
+refund, direct consumption, runtime-limit changes, and reconfiguration raise
+`BackendLockContentionError` if the writer remains locked past that timeout. A
+failed transaction makes no state change, so the operation is safe to retry.
+
+`acquire_capacity(..., timeout=0)` is a real try-acquire: its write-lock wait is
+set to zero for that attempt, and either insufficient capacity or a busy writer
+produces `TimeoutError` promptly. A finite positive acquire timeout bounds both
+capacity waiting and SQLite write-lock waiting. With no acquire timeout,
+temporary lock contention is retried as part of the ordinary wait loop.
+
+Blocked capacity waiters poll because SQLite has no cross-process notification
+channel. Poll intervals follow the refill estimate, are capped at one second,
+and include jitter to reduce synchronized wakeups. Scheduling is not FIFO.
+
+## Worker crashes and late refunds
+
+Killing a worker does not return its reservation in a burst. The consumed
+capacity recovers only through normal linear refill, exactly as if the request
+had used the full reservation. The orphaned acquire marker remains until its
+reservation lifetime expires and lazy pruning removes it.
+
+After marker expiry, a late refund fails closed with
+`UnknownReservationError`; it never creates capacity that cannot be tied to a
+live marker. A successful refund consumes the marker and writes a tombstone, so
+a duplicate refund fails without double-crediting capacity. After the tombstone
+TTL expires, another attempt is unknown rather than accepted.
+
+## Performance envelope
+
+SQLite is intended for CLI/cron scale and modest local worker pools: tens of
+processes and roughly up to 100 acquire/refund operations per second per
+database file. This is a planning envelope, not a throughput guarantee; disk,
+filesystem, quota concentration, and transaction duration determine the real
+limit.
+
+If write-lock waits are common, tail latency matters, or traffic is growing
+beyond this envelope, move the shared budget to Redis. Do not split one logical
+budget across multiple SQLite files to gain throughput; that creates
+independent limits.
+
+## Troubleshooting
+
+### `database is locked` or repeated `BackendLockContentionError`
+
+Confirm every process uses a writable local filesystem and that no external
+tool is holding a long write transaction. Leave the database's `-wal` and
+`-shm` sidecar files under SQLite's control while processes are running.
+Increasing `busy_timeout_ms` can absorb short bursts, but repeated contention
+usually means the workload needs less concurrency, separate unrelated database
+files, or Redis. For `timeout=0` acquires, immediate `TimeoutError` under a
+writer lock is expected and should be handled like unavailable capacity.
+
+### Clock warnings
+
+Check the host's current time, synchronization service, suspend/resume history,
+and VM snapshot history. A backward-clock warning means refill was clamped
+rather than calculated from negative elapsed time; a sufficiently future stored
+timestamp is repaired without adding capacity. A forward clock jump cannot be
+distinguished from real elapsed time and may refill up to the bucket maximum.
+Do not delete the database as a clock repair: deleting it resets shared bucket
+state to fresh capacity.
+
+### Processes do not appear to share a budget
+
+Log and compare each builder's resolved `db_path` and `key_prefix`. Relative
+paths from different working directories, container-local filesystems, and
+different prefixes all create independent state. Move every process to one
+stable absolute path on a shared local volume; do not solve the mismatch with a
+network filesystem.

--- a/tests/conformance/test_backend_conformance.py
+++ b/tests/conformance/test_backend_conformance.py
@@ -7,6 +7,7 @@ import pytest
 
 from token_throttle import (
     BackendConformanceError,
+    SqliteBackendBuilder,
     SyncSqliteBackendBuilder,
     conformance_test_for,
     sync_conformance_test_for,
@@ -27,6 +28,16 @@ if TYPE_CHECKING:
 
 async def test_async_memory_backend_passes_public_conformance_suite() -> None:
     await conformance_test_for(MemoryBackendBuilder(sleep_interval=0.01))
+
+
+async def test_async_sqlite_backend_passes_public_conformance_suite(tmp_path) -> None:
+    await conformance_test_for(
+        SqliteBackendBuilder(
+            tmp_path / "async-conformance.sqlite3",
+            key_prefix="async-sqlite-conformance",
+            sleep_interval=0.01,
+        )
+    )
 
 
 def test_sync_memory_backend_passes_public_conformance_suite() -> None:

--- a/tests/conformance/test_backend_conformance.py
+++ b/tests/conformance/test_backend_conformance.py
@@ -7,6 +7,7 @@ import pytest
 
 from token_throttle import (
     BackendConformanceError,
+    SyncSqliteBackendBuilder,
     conformance_test_for,
     sync_conformance_test_for,
 )
@@ -30,6 +31,16 @@ async def test_async_memory_backend_passes_public_conformance_suite() -> None:
 
 def test_sync_memory_backend_passes_public_conformance_suite() -> None:
     sync_conformance_test_for(SyncMemoryBackendBuilder(sleep_interval=0.01))
+
+
+def test_sync_sqlite_backend_passes_public_conformance_suite(tmp_path) -> None:
+    sync_conformance_test_for(
+        SyncSqliteBackendBuilder(
+            tmp_path / "conformance.sqlite3",
+            key_prefix="sync-sqlite-conformance",
+            sleep_interval=0.01,
+        )
+    )
 
 
 class _MarkerLiarAsyncBackend(RateLimiterBackend):

--- a/tests/integration/test_backend_behavior.py
+++ b/tests/integration/test_backend_behavior.py
@@ -358,13 +358,16 @@ async def test_refill_capped_at_max_capacity(backend_builder):
     elapsed = time.monotonic() - start
     assert elapsed < 1.0
 
-    # But 1 more should require waiting (we just consumed 5 of 5). Refill
-    # accrues from the drain's commit, so anchor there: measuring only around
-    # the next call lets client-side overhead (coverage tracing, round trips)
-    # eat into the 0.2s refill window and deflate the wait below the floor.
-    drained_at = time.monotonic()
+    # But 1 more should require waiting (we just consumed 5 of 5). The 0.2s
+    # refill window is timed from the drain's *commit*, which happens inside
+    # the call above; any anchor taken after that call subtracts the
+    # commit-to-return path (callback dispatch, instrumentation) from the
+    # window and can deflate the wait below the floor. Anchor before the
+    # drain call instead: the measured window then strictly contains the
+    # backend-enforced commit-to-grant interval, so client-side overhead can
+    # only inflate it.
     await backend.await_for_capacity(frozen_usage({"requests": 1}))
-    elapsed = time.monotonic() - drained_at
+    elapsed = time.monotonic() - start
     assert elapsed >= 0.1
 
 

--- a/tests/integration/test_backend_behavior.py
+++ b/tests/integration/test_backend_behavior.py
@@ -358,10 +358,13 @@ async def test_refill_capped_at_max_capacity(backend_builder):
     elapsed = time.monotonic() - start
     assert elapsed < 1.0
 
-    # But 1 more should require waiting (we just consumed 5 of 5).
-    start = time.monotonic()
+    # But 1 more should require waiting (we just consumed 5 of 5). Refill
+    # accrues from the drain's commit, so anchor there: measuring only around
+    # the next call lets client-side overhead (coverage tracing, round trips)
+    # eat into the 0.2s refill window and deflate the wait below the floor.
+    drained_at = time.monotonic()
     await backend.await_for_capacity(frozen_usage({"requests": 1}))
-    elapsed = time.monotonic() - start
+    elapsed = time.monotonic() - drained_at
     assert elapsed >= 0.1
 
 

--- a/tests/multiprocess/__init__.py
+++ b/tests/multiprocess/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-process integration tests and their spawn-based harness."""

--- a/tests/multiprocess/_harness.py
+++ b/tests/multiprocess/_harness.py
@@ -124,10 +124,14 @@ def _build_limiter(
     elif backend_spec.kind == "memory":
         builder = SyncMemoryBackendBuilder()
     elif backend_spec.kind == "sqlite":
-        # This branch is the only harness edit the parallel SQLite lane needs.
-        # Its public builder name is intentionally not guessed before that API lands.
-        raise NotImplementedError(
-            "SQLite backend builder is not available in this lane"
+        if backend_spec.locator is None:
+            raise ValueError("SQLite backend spec requires a database-path locator")
+        from token_throttle import SyncSqliteBackendBuilder  # noqa: PLC0415
+
+        builder = SyncSqliteBackendBuilder(
+            db_path=backend_spec.locator,
+            key_prefix=backend_spec.key_prefix,
+            **options,
         )
     else:  # pragma: no cover - Literal plus spawn input validation makes this defensive.
         raise ValueError(f"Unknown backend kind: {backend_spec.kind}")

--- a/tests/multiprocess/_harness.py
+++ b/tests/multiprocess/_harness.py
@@ -258,6 +258,37 @@ def _hold_until_killed(
     return {"unexpected_release": True}
 
 
+def _hold_sqlite_write_transaction(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    if backend_spec.kind != "sqlite" or backend_spec.locator is None:
+        raise ValueError("write-transaction injection requires a SQLite backend spec")
+    release_gate = payload["release_gate"]
+    import sqlite3  # noqa: PLC0415
+
+    # Build the process-affine public limiter first. The second connection is a
+    # test-only fault-injection seam that holds a real cross-process writer lock.
+    with (
+        _build_limiter(backend_spec, limiter_spec),
+        sqlite3.connect(
+            backend_spec.locator,
+            timeout=0.1,
+            isolation_level=None,
+        ) as lock_connection,
+    ):
+        lock_connection.execute("PRAGMA busy_timeout=100")
+        lock_connection.execute("BEGIN IMMEDIATE")
+        try:
+            _send(connection, "write_locked", locked_monotonic=time.monotonic())
+            _wait_for_gate(release_gate, scaled(20), name="write-release")
+        finally:
+            lock_connection.execute("ROLLBACK")
+    return {"released_monotonic": time.monotonic()}
+
+
 def _try_acquire(
     connection: Connection,
     backend_spec: BackendSpec,
@@ -284,6 +315,29 @@ def _try_acquire(
             "finished_monotonic": time.monotonic(),
             "reservation_id": reservation.reservation_id,
         }
+
+
+def _timed_try_acquire(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    amount = float(payload["amount"])
+    started = time.monotonic()
+    try:
+        with _build_limiter(backend_spec, limiter_spec) as limiter:
+            limiter.acquire_capacity({"requests": amount}, MODEL, timeout=0)
+    except TimeoutError:
+        outcome = "TimeoutError"
+    except Exception as exc:
+        outcome = type(exc).__name__
+    else:
+        outcome = "acquired"
+    return {
+        "elapsed": time.monotonic() - started,
+        "outcome": outcome,
+    }
 
 
 def _replay_refund(
@@ -350,10 +404,12 @@ def _contention_cycles(
 _ACTIONS = {
     "contention_cycles": _contention_cycles,
     "greedy_acquire": _greedy_acquire,
+    "hold_sqlite_write_transaction": _hold_sqlite_write_transaction,
     "hold_then_refund": _hold_then_refund,
     "hold_until_killed": _hold_until_killed,
     "replay_refund": _replay_refund,
     "try_acquire": _try_acquire,
+    "timed_try_acquire": _timed_try_acquire,
     "wait_for_refund": _wait_for_refund,
 }
 

--- a/tests/multiprocess/_harness.py
+++ b/tests/multiprocess/_harness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import math
 import multiprocessing
 import os
 import threading
@@ -68,11 +69,11 @@ def timing_scale() -> float:
         scale = float(raw)
     except ValueError as exc:
         raise ValueError(
-            "TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE must be a positive number"
+            "TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE must be a finite number >= 1"
         ) from exc
-    if scale <= 0:
+    if not math.isfinite(scale) or scale < 1:
         raise ValueError(
-            "TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE must be a positive number"
+            "TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE must be a finite number >= 1"
         )
     return scale
 

--- a/tests/multiprocess/_harness.py
+++ b/tests/multiprocess/_harness.py
@@ -324,16 +324,22 @@ def _timed_try_acquire(
     payload: Mapping[str, object],
 ) -> dict[str, object]:
     amount = float(payload["amount"])
-    started = time.monotonic()
-    try:
-        with _build_limiter(backend_spec, limiter_spec) as limiter:
+    start_gate = payload.get("start_gate")
+    with _build_limiter(backend_spec, limiter_spec) as limiter:
+        if start_gate is not None:
+            preflight = limiter.acquire_capacity({"requests": amount}, MODEL, timeout=0)
+            limiter.refund_capacity({"requests": 0}, preflight)
+            _send(connection, "ready", pid=os.getpid())
+            _wait_for_gate(start_gate, scaled(15), name="timed-acquire-start")
+        started = time.monotonic()
+        try:
             limiter.acquire_capacity({"requests": amount}, MODEL, timeout=0)
-    except TimeoutError:
-        outcome = "TimeoutError"
-    except Exception as exc:
-        outcome = type(exc).__name__
-    else:
-        outcome = "acquired"
+        except TimeoutError:
+            outcome = "TimeoutError"
+        except Exception as exc:
+            outcome = type(exc).__name__
+        else:
+            outcome = "acquired"
     return {
         "elapsed": time.monotonic() - started,
         "outcome": outcome,

--- a/tests/multiprocess/_harness.py
+++ b/tests/multiprocess/_harness.py
@@ -1,0 +1,463 @@
+"""Spawn-based, backend-agnostic child runner for integration scenarios."""
+
+from __future__ import annotations
+
+import contextlib
+import multiprocessing
+import os
+import threading
+import time
+import traceback
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from token_throttle import (
+    CapacityReservation,
+    DuplicateRefundError,
+    PerModelConfig,
+    Quota,
+    SyncMemoryBackendBuilder,
+    SyncRateLimiter,
+    SyncRateLimiterCallbacks,
+    UnknownReservationError,
+    UsageQuotas,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+    from multiprocessing.connection import Connection
+
+MODEL = "multiprocess-model"
+MODEL_FAMILY = "multiprocess-family"
+RESULT_EVENT = "result"
+ERROR_EVENT = "error"
+MAX_TRACEBACK_CHARS = 8_000
+
+
+@dataclass(frozen=True, slots=True)
+class BackendSpec:
+    """Serializable instructions for constructing a backend inside a child."""
+
+    kind: Literal["memory", "redis", "sqlite"]
+    locator: str | None
+    key_prefix: str
+    options: tuple[tuple[str, int | float | bool], ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
+class LimiterSpec:
+    """Serializable quota and limiter-lifetime inputs for a child."""
+
+    limit: float
+    per_seconds: int
+    max_reservation_lifetime_seconds: float | None = None
+
+
+@dataclass(slots=True)
+class ChildHandle:
+    """Parent-owned process and receive-only result channel."""
+
+    process: multiprocessing.Process
+    connection: Connection
+
+
+def timing_scale() -> float:
+    """Return the opt-in multiplier used for process and polling deadlines."""
+    raw = os.environ.get("TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE", "1")
+    try:
+        scale = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            "TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE must be a positive number"
+        ) from exc
+    if scale <= 0:
+        raise ValueError(
+            "TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE must be a positive number"
+        )
+    return scale
+
+
+def scaled(seconds: float) -> float:
+    """Scale a process/polling deadline without changing quota arithmetic."""
+    return seconds * timing_scale()
+
+
+def _config(spec: LimiterSpec) -> PerModelConfig:
+    return PerModelConfig(
+        model_family=MODEL_FAMILY,
+        quotas=UsageQuotas(
+            [
+                Quota(
+                    metric="requests",
+                    limit=spec.limit,
+                    per_seconds=spec.per_seconds,
+                )
+            ]
+        ),
+    )
+
+
+@contextlib.contextmanager
+def _build_limiter(
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    *,
+    callbacks: SyncRateLimiterCallbacks | None = None,
+) -> Iterator[SyncRateLimiter]:
+    """Build all process-affine objects after the child has spawned."""
+    options = dict(backend_spec.options)
+    if backend_spec.kind == "redis":
+        if backend_spec.locator is None:
+            raise ValueError("Redis backend spec requires a URL locator")
+        import redis  # noqa: PLC0415
+
+        from token_throttle import SyncRedisBackendBuilder  # noqa: PLC0415
+
+        client = redis.from_url(backend_spec.locator)
+        builder = SyncRedisBackendBuilder(
+            client,
+            key_prefix=backend_spec.key_prefix,
+            owns_redis_client=True,
+            **options,
+        )
+    elif backend_spec.kind == "memory":
+        builder = SyncMemoryBackendBuilder()
+    elif backend_spec.kind == "sqlite":
+        # This branch is the only harness edit the parallel SQLite lane needs.
+        # Its public builder name is intentionally not guessed before that API lands.
+        raise NotImplementedError(
+            "SQLite backend builder is not available in this lane"
+        )
+    else:  # pragma: no cover - Literal plus spawn input validation makes this defensive.
+        raise ValueError(f"Unknown backend kind: {backend_spec.kind}")
+
+    with SyncRateLimiter(
+        _config(limiter_spec),
+        backend=builder,
+        callbacks=callbacks,
+        max_reservation_lifetime_seconds=(
+            limiter_spec.max_reservation_lifetime_seconds
+        ),
+    ) as limiter:
+        yield limiter
+
+
+def _send(connection: Connection, event: str, **payload: object) -> None:
+    connection.send({"event": event, **payload})
+
+
+def _wait_for_gate(gate: object, timeout: float, *, name: str) -> None:
+    wait = getattr(gate, "wait", None)
+    if not callable(wait) or not wait(timeout=timeout):
+        raise TimeoutError(f"timed out waiting for parent {name} gate")
+
+
+def _greedy_acquire(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    start_gate = payload["start_gate"]
+    _send(connection, "ready", pid=os.getpid())
+    _wait_for_gate(start_gate, scaled(15), name="start")
+    started = time.monotonic()
+    granted = 0
+    with _build_limiter(backend_spec, limiter_spec) as limiter:
+        while True:
+            try:
+                limiter.acquire_capacity({"requests": 1}, MODEL, timeout=0)
+            except TimeoutError:
+                break
+            granted += 1
+    return {
+        "granted": granted,
+        "started_monotonic": started,
+        "finished_monotonic": time.monotonic(),
+    }
+
+
+def _hold_then_refund(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    release_gate = payload["release_gate"]
+    with _build_limiter(backend_spec, limiter_spec) as limiter:
+        reservation = limiter.acquire_capacity(
+            {"requests": limiter_spec.limit}, MODEL, timeout=0
+        )
+        _send(
+            connection,
+            "acquired",
+            reservation_id=reservation.reservation_id,
+            acquired_monotonic=time.monotonic(),
+        )
+        _wait_for_gate(release_gate, scaled(15), name="refund")
+        limiter.refund_capacity({"requests": 0}, reservation)
+        refunded_monotonic = time.monotonic()
+    return {"refunded_monotonic": refunded_monotonic}
+
+
+def _wait_for_refund(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    wait_timeout = float(payload["wait_timeout"])
+    waiting_sent = False
+
+    def on_wait_start(**_kwargs: object) -> None:
+        nonlocal waiting_sent
+        if not waiting_sent:
+            waiting_sent = True
+            _send(connection, "waiting", waiting_monotonic=time.monotonic())
+
+    callbacks = SyncRateLimiterCallbacks(on_wait_start=on_wait_start)
+    started = time.monotonic()
+    with _build_limiter(backend_spec, limiter_spec, callbacks=callbacks) as limiter:
+        reservation = limiter.acquire_capacity(
+            {"requests": 1}, MODEL, timeout=wait_timeout
+        )
+        reservation_id = reservation.reservation_id
+    return {
+        "reservation_id": reservation_id,
+        "elapsed": time.monotonic() - started,
+        "finished_monotonic": time.monotonic(),
+    }
+
+
+def _hold_until_killed(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    with _build_limiter(backend_spec, limiter_spec) as limiter:
+        reservation = limiter.acquire_capacity(
+            {"requests": limiter_spec.limit}, MODEL, timeout=0
+        )
+        _send(
+            connection,
+            "acquired",
+            acquired_monotonic=time.monotonic(),
+            reservation_json=reservation.model_dump_json(),
+            reservation_id=reservation.reservation_id,
+        )
+        # This event is deliberately process-local. A shared multiprocessing
+        # Condition can be left permanently wedged if SIGKILL lands while the
+        # child is inside Condition.wait(), making parent cleanup deadlock.
+        threading.Event().wait(timeout=scaled(3_600))
+    return {"unexpected_release": True}
+
+
+def _try_acquire(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    amount = float(payload["amount"])
+    timeout = float(payload.get("timeout", 0.0))
+    started = time.monotonic()
+    with _build_limiter(backend_spec, limiter_spec) as limiter:
+        try:
+            reservation = limiter.acquire_capacity(
+                {"requests": amount}, MODEL, timeout=timeout
+            )
+        except TimeoutError:
+            return {
+                "acquired": False,
+                "elapsed": time.monotonic() - started,
+                "finished_monotonic": time.monotonic(),
+            }
+        return {
+            "acquired": True,
+            "elapsed": time.monotonic() - started,
+            "finished_monotonic": time.monotonic(),
+            "reservation_id": reservation.reservation_id,
+        }
+
+
+def _replay_refund(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    reservation = CapacityReservation.model_validate_json(
+        str(payload["reservation_json"])
+    )
+    with _build_limiter(backend_spec, limiter_spec) as limiter:
+        # Deliberate fault-injection seam: ordinary public use must not move a
+        # reservation between limiter instances. Matching the trusted issuing ID
+        # lets this scenario reach the shared backend's expired-marker decision.
+        limiter._limiter_instance_id = reservation.limiter_instance_id
+        try:
+            limiter.refund_capacity({"requests": 0}, reservation)
+        except (UnknownReservationError, DuplicateRefundError) as exc:
+            return {
+                "exception_type": type(exc).__name__,
+                "reason": exc.reason,
+            }
+    return {"exception_type": None, "reason": None}
+
+
+def _contention_cycles(
+    connection: Connection,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    start_gate = payload["start_gate"]
+    active = payload["active"]
+    max_active = payload["max_active"]
+    cycles = int(payload["cycles"])
+    hold_seconds = float(payload["hold_seconds"])
+    wait_timeout = float(payload["wait_timeout"])
+    _send(connection, "ready", pid=os.getpid())
+    _wait_for_gate(start_gate, scaled(15), name="start")
+    reservation_ids: set[str] = set()
+    with _build_limiter(backend_spec, limiter_spec) as limiter:
+        for _ in range(cycles):
+            reservation = limiter.acquire_capacity(
+                {"requests": 1}, MODEL, timeout=wait_timeout
+            )
+            reservation_ids.add(reservation.reservation_id)
+            active_lock = active.get_lock()
+            with active_lock:
+                active.value += 1
+                max_active.value = max(max_active.value, active.value)
+            try:
+                time.sleep(hold_seconds)
+                limiter.refund_capacity({"requests": 0}, reservation)
+            finally:
+                with active_lock:
+                    active.value -= 1
+    return {
+        "cycles": cycles,
+        "distinct_reservations": len(reservation_ids),
+    }
+
+
+_ACTIONS = {
+    "contention_cycles": _contention_cycles,
+    "greedy_acquire": _greedy_acquire,
+    "hold_then_refund": _hold_then_refund,
+    "hold_until_killed": _hold_until_killed,
+    "replay_refund": _replay_refund,
+    "try_acquire": _try_acquire,
+    "wait_for_refund": _wait_for_refund,
+}
+
+
+def _child_main(
+    connection: Connection,
+    action: str,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    payload: Mapping[str, object],
+) -> None:
+    try:
+        handler = _ACTIONS[action]
+        result = handler(connection, backend_spec, limiter_spec, payload)
+        _send(connection, RESULT_EVENT, **result)
+    except BaseException as exc:
+        _send(
+            connection,
+            ERROR_EVENT,
+            exception_type=type(exc).__name__,
+            message=str(exc),
+            traceback=traceback.format_exc(limit=12)[-MAX_TRACEBACK_CHARS:],
+        )
+    finally:
+        connection.close()
+
+
+def spawn_child(
+    action: str,
+    backend_spec: BackendSpec,
+    limiter_spec: LimiterSpec,
+    **payload: object,
+) -> ChildHandle:
+    """Start a fresh-interpreter worker with a bounded one-way result pipe."""
+    context = multiprocessing.get_context("spawn")
+    receive_connection, send_connection = context.Pipe(duplex=False)
+    process = context.Process(
+        target=_child_main,
+        args=(send_connection, action, backend_spec, limiter_spec, payload),
+        name=f"token-throttle-mp-{action}",
+    )
+    process.start()
+    send_connection.close()
+    return ChildHandle(process=process, connection=receive_connection)
+
+
+def receive_event(
+    child: ChildHandle,
+    expected_event: str,
+    *,
+    timeout: float,
+) -> dict[str, object]:
+    """Receive one child message before a deadline and validate its event type."""
+    if not child.connection.poll(timeout):
+        raise AssertionError(
+            f"child {child.process.name!r} did not report {expected_event!r} "
+            f"within {timeout:g}s (alive={child.process.is_alive()}, "
+            f"exitcode={child.process.exitcode})"
+        )
+    try:
+        message = child.connection.recv()
+    except EOFError as exc:
+        raise AssertionError(
+            f"child {child.process.name!r} closed its result pipe before "
+            f"reporting {expected_event!r} (exitcode={child.process.exitcode})"
+        ) from exc
+    if not isinstance(message, dict):
+        raise AssertionError(  # noqa: TRY004
+            f"child sent non-dictionary result: {message!r}"
+        )
+    event = message.get("event")
+    if event == ERROR_EVENT:
+        raise AssertionError(
+            f"child {child.process.name!r} failed with "
+            f"{message.get('exception_type')}: {message.get('message')}\n"
+            f"{message.get('traceback')}"
+        )
+    if event != expected_event:
+        raise AssertionError(
+            f"child {child.process.name!r} reported event {event!r}; "
+            f"expected {expected_event!r}: {message!r}"
+        )
+    return message
+
+
+def finish_child(child: ChildHandle, *, timeout: float) -> dict[str, object]:
+    """Receive the terminal result, then join without permitting a suite hang."""
+    result = receive_event(child, RESULT_EVENT, timeout=timeout)
+    child.process.join(timeout=timeout)
+    if child.process.is_alive():
+        child.process.terminate()
+        child.process.join(timeout=scaled(3))
+        raise AssertionError(
+            f"child {child.process.name!r} reported a result but did not exit "
+            f"within {timeout:g}s"
+        )
+    child.connection.close()
+    if child.process.exitcode != 0:
+        raise AssertionError(
+            f"child {child.process.name!r} exited with {child.process.exitcode}"
+        )
+    return result
+
+
+def terminate_children(children: list[ChildHandle]) -> None:
+    """Best-effort cleanup for children left alive by a failed assertion."""
+    for child in children:
+        if child.process.is_alive():
+            child.process.terminate()
+    for child in children:
+        child.process.join(timeout=scaled(3))
+        child.connection.close()

--- a/tests/multiprocess/conftest.py
+++ b/tests/multiprocess/conftest.py
@@ -116,6 +116,12 @@ def _sqlite_case(tmp_path: Path) -> BackendCase:
     )
 
 
+@pytest.fixture
+def sqlite_backend_case(tmp_path: Path) -> BackendCase:
+    """Yield a SQLite-only backend case without evaluating Redis fixtures."""
+    return _sqlite_case(tmp_path)
+
+
 @pytest.fixture(
     params=[
         pytest.param("redis", marks=pytest.mark.redis, id="redis"),

--- a/tests/multiprocess/conftest.py
+++ b/tests/multiprocess/conftest.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import sqlite3
 import time
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 
 import pytest
 
@@ -26,7 +28,18 @@ class BackendCase:
     spec: BackendSpec
     observer: object | None = None
 
-    def marker_exists(self, reservation_id: str) -> bool:
+    def marker_is_live(self, reservation_id: str) -> bool:
+        if self.spec.kind == "sqlite":
+            if self.spec.locator is None:
+                raise AssertionError("SQLite backend case has no database path")
+            read_only_uri = f"{Path(self.spec.locator).resolve().as_uri()}?mode=ro"
+            with sqlite3.connect(read_only_uri, uri=True) as connection:
+                row = connection.execute(
+                    "SELECT expires_at FROM acquire_markers "
+                    "WHERE key_prefix = ? AND reservation_id = ?",
+                    (self.spec.key_prefix, reservation_id),
+                ).fetchone()
+            return row is not None and float(row[0]) > time.time()
         if self.spec.kind != "redis" or self.observer is None:
             raise NotImplementedError(
                 f"marker inspection is not implemented for {self.spec.kind}"
@@ -43,7 +56,7 @@ class BackendCase:
 
     def wait_until_marker_expires(self, reservation_id: str, *, timeout: float) -> None:
         deadline = time.monotonic() + timeout
-        while self.marker_exists(reservation_id):
+        while self.marker_is_live(reservation_id):
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 raise AssertionError(
@@ -92,9 +105,32 @@ def _redis_case(redis_url: str) -> tuple[BackendCase, object]:
     )
 
 
-@pytest.fixture(params=[pytest.param("redis", marks=pytest.mark.redis)])
-def shared_backend_case(request: pytest.FixtureRequest, redis_url: str):
-    """Yield shared backends; add SQLite to this parameter list when it lands."""
+def _sqlite_case(tmp_path: Path) -> BackendCase:
+    return BackendCase(
+        spec=BackendSpec(
+            kind="sqlite",
+            locator=str(tmp_path / "shared-state.sqlite3"),
+            key_prefix=f"mp-{uuid.uuid4().hex}",
+            options=(("sleep_interval", 0.02),),
+        )
+    )
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("redis", marks=pytest.mark.redis, id="redis"),
+        pytest.param("sqlite", id="sqlite"),
+    ]
+)
+def shared_backend_case(
+    request: pytest.FixtureRequest,
+    redis_url: str,
+    tmp_path: Path,
+):
+    """Yield each cross-process-capable backend without coupling their setup."""
+    if request.param == "sqlite":
+        yield _sqlite_case(tmp_path)
+        return
     if request.param != "redis":
         raise ValueError(f"Unknown shared backend: {request.param}")
     case, client = _redis_case(redis_url)
@@ -107,9 +143,11 @@ def shared_backend_case(request: pytest.FixtureRequest, redis_url: str):
 
 @pytest.fixture(
     params=[
-        pytest.param("redis", marks=pytest.mark.redis),
+        pytest.param("redis", marks=pytest.mark.redis, id="redis"),
+        pytest.param("sqlite", id="sqlite"),
         pytest.param(
             "memory",
+            id="memory",
             marks=pytest.mark.xfail(
                 strict=True,
                 reason=(
@@ -120,13 +158,22 @@ def shared_backend_case(request: pytest.FixtureRequest, redis_url: str):
         ),
     ]
 )
-def fresh_interpreter_backend_case(request: pytest.FixtureRequest, redis_url: str):
+def fresh_interpreter_backend_case(
+    request: pytest.FixtureRequest,
+    redis_url: str,
+    tmp_path: Path,
+):
     """Include memory as a strict expected-failure control for the process cliff."""
     if request.param == "memory":
         yield BackendCase(
             spec=BackendSpec(kind="memory", locator=None, key_prefix="unused")
         )
         return
+    if request.param == "sqlite":
+        yield _sqlite_case(tmp_path)
+        return
+    if request.param != "redis":
+        raise ValueError(f"Unknown fresh-interpreter backend: {request.param}")
     case, client = _redis_case(redis_url)
     try:
         yield case

--- a/tests/multiprocess/conftest.py
+++ b/tests/multiprocess/conftest.py
@@ -1,0 +1,135 @@
+"""Redis-safe backend fixtures for the multi-process scenarios."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+
+import pytest
+
+from tests._redis_guard import ensure_flush_allowed
+from tests.multiprocess._harness import BackendSpec, scaled
+
+REQUIRED_REDIS_DB = 13
+
+
+@pytest.fixture
+def redis_url(request: pytest.FixtureRequest) -> str:
+    return str(request.config.getoption("--redis-url"))
+
+
+@dataclass(slots=True)
+class BackendCase:
+    """Parent-side backend controls paired with the child-build specification."""
+
+    spec: BackendSpec
+    observer: object | None = None
+
+    def marker_exists(self, reservation_id: str) -> bool:
+        if self.spec.kind != "redis" or self.observer is None:
+            raise NotImplementedError(
+                f"marker inspection is not implemented for {self.spec.kind}"
+            )
+        from token_throttle._limiter_backends._redis._keys import (  # noqa: PLC0415
+            redis_acquired_marker_key,
+        )
+
+        return bool(
+            self.observer.exists(
+                redis_acquired_marker_key(self.spec.key_prefix, reservation_id)
+            )
+        )
+
+    def wait_until_marker_expires(self, reservation_id: str, *, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while self.marker_exists(reservation_id):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError(
+                    f"reservation marker {reservation_id!r} did not expire "
+                    f"within {timeout:g}s"
+                )
+            time.sleep(min(scaled(0.05), remaining))
+
+
+def _redis_case(redis_url: str) -> tuple[BackendCase, object]:
+    sync_redis = pytest.importorskip("redis", reason="redis package not installed")
+    redis_exceptions = pytest.importorskip(
+        "redis.exceptions", reason="redis package not installed"
+    )
+    client = sync_redis.from_url(redis_url)
+    try:
+        client.ping()
+    except redis_exceptions.RedisError as exc:
+        client.close()
+        pytest.skip(f"Redis unavailable at {redis_url}: {exc}")
+
+    selected_db = int(client.connection_pool.connection_kwargs.get("db", 0))
+    if selected_db != REQUIRED_REDIS_DB:
+        client.close()
+        pytest.fail(
+            "multi-process tests require a dedicated Redis logical database: "
+            f"pass --redis-url redis://localhost:6379/{REQUIRED_REDIS_DB} "
+            f"(configured DB is {selected_db})",
+            pytrace=False,
+        )
+
+    ensure_flush_allowed(redis_url)
+    client.flushdb()
+    prefix = f"mp-{uuid.uuid4().hex}"
+    return (
+        BackendCase(
+            spec=BackendSpec(
+                kind="redis",
+                locator=redis_url,
+                key_prefix=prefix,
+                options=(("sleep_interval", 0.02),),
+            ),
+            observer=client,
+        ),
+        client,
+    )
+
+
+@pytest.fixture(params=[pytest.param("redis", marks=pytest.mark.redis)])
+def shared_backend_case(request: pytest.FixtureRequest, redis_url: str):
+    """Yield shared backends; add SQLite to this parameter list when it lands."""
+    if request.param != "redis":
+        raise ValueError(f"Unknown shared backend: {request.param}")
+    case, client = _redis_case(redis_url)
+    try:
+        yield case
+    finally:
+        client.flushdb()
+        client.close()
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("redis", marks=pytest.mark.redis),
+        pytest.param(
+            "memory",
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "MemoryBackend state is process-local; a fresh interpreter "
+                    "cannot observe prior consumption"
+                ),
+            ),
+        ),
+    ]
+)
+def fresh_interpreter_backend_case(request: pytest.FixtureRequest, redis_url: str):
+    """Include memory as a strict expected-failure control for the process cliff."""
+    if request.param == "memory":
+        yield BackendCase(
+            spec=BackendSpec(kind="memory", locator=None, key_prefix="unused")
+        )
+        return
+    case, client = _redis_case(redis_url)
+    try:
+        yield case
+    finally:
+        client.flushdb()
+        client.close()

--- a/tests/multiprocess/test_shared_backend_processes.py
+++ b/tests/multiprocess/test_shared_backend_processes.py
@@ -14,7 +14,8 @@ not exact scheduler sleeps.
 
 CI intent: run this directory in the Linux Redis ``test-integration`` job with
 ``--redis-url redis://localhost:6379/13``. Allow roughly twice the ordinary
-integration-test wall time. Slow runners may set
+integration-test wall time. SQLite parameters remain runnable when Redis is
+unavailable. Slow runners may set
 ``TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE=2`` to scale process/join deadlines;
 quota/refill arithmetic remains unchanged. CI workflow edits are intentionally
 outside this lane.

--- a/tests/multiprocess/test_shared_backend_processes.py
+++ b/tests/multiprocess/test_shared_backend_processes.py
@@ -139,7 +139,10 @@ def test_killed_reservation_recovers_only_by_refill(shared_backend_case) -> None
     replay_spec = LimiterSpec(
         limit=limit,
         per_seconds=per_seconds,
-        max_reservation_lifetime_seconds=5.0 * timing_scale(),
+        # The acquiring child alone controls the short marker TTL. Give replay
+        # children a much wider public-API lifetime so slow process startup
+        # cannot reject by age before Redis gets to report the missing marker.
+        max_reservation_lifetime_seconds=30.0 * timing_scale(),
     )
     holder = spawn_child(
         "hold_until_killed",

--- a/tests/multiprocess/test_shared_backend_processes.py
+++ b/tests/multiprocess/test_shared_backend_processes.py
@@ -1,0 +1,289 @@
+"""
+Real-process shared-backend scenarios.
+
+Workers use ``multiprocessing.get_context("spawn")`` rather than ``fork``.
+Spawn is portable and imports this module in a fresh interpreter, while still
+supporting deterministic start gates. More importantly, every worker constructs
+its own limiter, backend builder, and backend client after the process boundary;
+none of those documented process-affine objects are inherited or pickled.
+
+Results are small dictionaries sent over receive-only parent pipes. Every poll,
+gate wait, and join has a deadline, and failed tests terminate only their owned
+children. Assertions use deadline polling and quota-derived refill tolerances,
+not exact scheduler sleeps.
+
+CI intent: run this directory in the Linux Redis ``test-integration`` job with
+``--redis-url redis://localhost:6379/13``. Allow roughly twice the ordinary
+integration-test wall time. Slow runners may set
+``TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE=2`` to scale process/join deadlines;
+quota/refill arithmetic remains unchanged. CI workflow edits are intentionally
+outside this lane.
+"""
+
+from __future__ import annotations
+
+import math
+import multiprocessing
+import os
+import signal
+import time
+
+import pytest
+
+from tests.multiprocess._harness import (
+    MODEL_FAMILY,
+    ChildHandle,
+    LimiterSpec,
+    finish_child,
+    receive_event,
+    scaled,
+    spawn_child,
+    terminate_children,
+    timing_scale,
+)
+
+
+def _finish_all(
+    children: list[ChildHandle], *, timeout: float
+) -> list[dict[str, object]]:
+    deadline = time.monotonic() + timeout
+    results = []
+    for child in children:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise AssertionError(
+                f"children did not all finish within shared {timeout:g}s deadline"
+            )
+        results.append(finish_child(child, timeout=remaining))
+    return results
+
+
+def test_cross_process_budget_enforcement(shared_backend_case) -> None:
+    process_count = 4
+    limit = 8
+    per_seconds = 60
+    limiter_spec = LimiterSpec(limit=limit, per_seconds=per_seconds)
+    context = multiprocessing.get_context("spawn")
+    start_gate = context.Event()
+    children = [
+        spawn_child(
+            "greedy_acquire",
+            shared_backend_case.spec,
+            limiter_spec,
+            start_gate=start_gate,
+        )
+        for _ in range(process_count)
+    ]
+    try:
+        for child in children:
+            receive_event(child, "ready", timeout=scaled(15))
+        released_at = time.monotonic()
+        start_gate.set()
+        results = _finish_all(children, timeout=scaled(20))
+    finally:
+        terminate_children(children)
+
+    finished_at = max(float(result["finished_monotonic"]) for result in results)
+    elapsed = finished_at - released_at
+    refill_tolerance = math.ceil(elapsed * limit / per_seconds)
+    total_granted = sum(int(result["granted"]) for result in results)
+    assert total_granted >= limit
+    assert total_granted <= limit + refill_tolerance
+
+
+def test_cross_process_refund_unblocks_waiter(shared_backend_case) -> None:
+    limit = 8
+    wait_timeout = scaled(10)
+    limiter_spec = LimiterSpec(limit=limit, per_seconds=60)
+    context = multiprocessing.get_context("spawn")
+    refund_gate = context.Event()
+    holder = spawn_child(
+        "hold_then_refund",
+        shared_backend_case.spec,
+        limiter_spec,
+        release_gate=refund_gate,
+    )
+    children = [holder]
+    try:
+        receive_event(holder, "acquired", timeout=scaled(15))
+        waiter = spawn_child(
+            "wait_for_refund",
+            shared_backend_case.spec,
+            limiter_spec,
+            wait_timeout=wait_timeout,
+        )
+        children.append(waiter)
+        receive_event(waiter, "waiting", timeout=scaled(15))
+        refund_gate.set()
+        holder_result = finish_child(holder, timeout=scaled(15))
+        waiter_result = finish_child(waiter, timeout=scaled(15))
+    finally:
+        refund_gate.set()
+        terminate_children(children)
+
+    assert float(waiter_result["finished_monotonic"]) >= float(
+        holder_result["refunded_monotonic"]
+    )
+    assert float(waiter_result["elapsed"]) < wait_timeout * 0.75
+
+
+@pytest.mark.skipif(os.name != "posix", reason="requires exact POSIX SIGKILL semantics")
+def test_killed_reservation_recovers_only_by_refill(shared_backend_case) -> None:
+    limit = 4
+    per_seconds = max(12, math.ceil(12 * timing_scale()))
+    acquiring_spec = LimiterSpec(
+        limit=limit,
+        per_seconds=per_seconds,
+        max_reservation_lifetime_seconds=0.75,
+    )
+    replay_spec = LimiterSpec(
+        limit=limit,
+        per_seconds=per_seconds,
+        max_reservation_lifetime_seconds=5.0 * timing_scale(),
+    )
+    holder = spawn_child(
+        "hold_until_killed",
+        shared_backend_case.spec,
+        acquiring_spec,
+    )
+    children = [holder]
+    try:
+        acquired = receive_event(holder, "acquired", timeout=scaled(15))
+        reservation_id = str(acquired["reservation_id"])
+        reservation_json = str(acquired["reservation_json"])
+        acquired_at = float(acquired["acquired_monotonic"])
+
+        assert holder.process.pid is not None
+        os.kill(holder.process.pid, signal.SIGKILL)
+        holder.process.join(timeout=scaled(5))
+        assert not holder.process.is_alive()
+        assert holder.process.exitcode == -signal.SIGKILL
+        holder.connection.close()
+
+        shared_backend_case.wait_until_marker_expires(reservation_id, timeout=scaled(5))
+
+        full_probe = spawn_child(
+            "try_acquire",
+            shared_backend_case.spec,
+            replay_spec,
+            amount=limit,
+            timeout=0,
+        )
+        children.append(full_probe)
+        full_result = finish_child(full_probe, timeout=scaled(15))
+        assert float(full_result["finished_monotonic"]) - acquired_at < per_seconds
+        assert full_result["acquired"] is False
+
+        replay = spawn_child(
+            "replay_refund",
+            shared_backend_case.spec,
+            replay_spec,
+            reservation_json=reservation_json,
+        )
+        children.append(replay)
+        replay_result = finish_child(replay, timeout=scaled(15))
+        assert replay_result["exception_type"] == "UnknownReservationError"
+        assert replay_result["reason"] == "unknown_reservation"
+
+        refill_probe = spawn_child(
+            "try_acquire",
+            shared_backend_case.spec,
+            replay_spec,
+            amount=1,
+            timeout=scaled(6),
+        )
+        children.append(refill_probe)
+        refill_result = finish_child(refill_probe, timeout=scaled(15))
+        assert refill_result["acquired"] is True
+    finally:
+        terminate_children(children)
+
+
+def test_contention_acquire_refund_cycles_preserve_capacity(
+    shared_backend_case,
+) -> None:
+    process_count = 6
+    cycles = 10
+    limit = 4
+    limiter_spec = LimiterSpec(limit=limit, per_seconds=60)
+    context = multiprocessing.get_context("spawn")
+    start_gate = context.Event()
+    active = context.Value("i", 0)
+    max_active = context.Value("i", 0)
+    children = [
+        spawn_child(
+            "contention_cycles",
+            shared_backend_case.spec,
+            limiter_spec,
+            start_gate=start_gate,
+            active=active,
+            max_active=max_active,
+            cycles=cycles,
+            hold_seconds=scaled(0.01),
+            wait_timeout=scaled(10),
+        )
+        for _ in range(process_count)
+    ]
+    try:
+        for child in children:
+            receive_event(child, "ready", timeout=scaled(15))
+        start_gate.set()
+        results = _finish_all(children, timeout=scaled(30))
+    finally:
+        start_gate.set()
+        terminate_children(children)
+
+    assert active.value == 0
+    assert 1 <= max_active.value <= limit
+    assert sum(int(result["cycles"]) for result in results) == process_count * cycles
+    assert all(int(result["distinct_reservations"]) == cycles for result in results)
+
+    probe_gate = context.Event()
+    final_probe = spawn_child(
+        "greedy_acquire",
+        shared_backend_case.spec,
+        limiter_spec,
+        start_gate=probe_gate,
+    )
+    probe_children = [final_probe]
+    try:
+        receive_event(final_probe, "ready", timeout=scaled(15))
+        probe_gate.set()
+        final_result = finish_child(final_probe, timeout=scaled(15))
+    finally:
+        terminate_children(probe_children)
+    assert int(final_result["granted"]) == limit
+
+
+def test_fresh_interpreter_observes_prior_consumption(
+    fresh_interpreter_backend_case,
+) -> None:
+    limiter_spec = LimiterSpec(limit=2, per_seconds=60)
+    first = spawn_child(
+        "try_acquire",
+        fresh_interpreter_backend_case.spec,
+        limiter_spec,
+        amount=2,
+        timeout=0,
+    )
+    children = [first]
+    try:
+        first_result = finish_child(first, timeout=scaled(15))
+        assert first_result["acquired"] is True
+
+        second = spawn_child(
+            "try_acquire",
+            fresh_interpreter_backend_case.spec,
+            limiter_spec,
+            amount=1,
+            timeout=0,
+        )
+        children.append(second)
+        second_result = finish_child(second, timeout=scaled(15))
+    finally:
+        terminate_children(children)
+
+    assert second_result["acquired"] is False, (
+        f"{fresh_interpreter_backend_case.spec.kind} did not preserve shared "
+        f"state for {MODEL_FAMILY} across fresh interpreters"
+    )

--- a/tests/multiprocess/test_sqlite_try_acquire_promptness.py
+++ b/tests/multiprocess/test_sqlite_try_acquire_promptness.py
@@ -33,28 +33,35 @@ def test_sqlite_try_acquire_returns_promptly_while_writer_holds_lock(
     limiter_spec = LimiterSpec(limit=4, per_seconds=60)
     context = multiprocessing.get_context("spawn")
     release_gate = context.Event()
+    probe_gate = context.Event()
+    probes = [
+        spawn_child(
+            "timed_try_acquire",
+            sqlite_backend_case.spec,
+            limiter_spec,
+            amount=1,
+            start_gate=probe_gate,
+        )
+        for _ in range(PROBE_COUNT)
+    ]
+    children: list[ChildHandle] = list(probes)
+    for probe in probes:
+        receive_event(probe, "ready", timeout=scaled(15))
+
     holder = spawn_child(
         "hold_sqlite_write_transaction",
         sqlite_backend_case.spec,
         limiter_spec,
         release_gate=release_gate,
     )
-    children: list[ChildHandle] = [holder]
+    children.append(holder)
     results: list[dict[str, object]] = []
     try:
         receive_event(holder, "write_locked", timeout=scaled(15))
-        probes = [
-            spawn_child(
-                "timed_try_acquire",
-                sqlite_backend_case.spec,
-                limiter_spec,
-                amount=1,
-            )
-            for _ in range(PROBE_COUNT)
-        ]
-        children.extend(probes)
+        probe_gate.set()
         results = [finish_child(probe, timeout=scaled(10)) for probe in probes]
     finally:
+        probe_gate.set()
         release_gate.set()
         if holder.process.is_alive():
             finish_child(holder, timeout=scaled(5))

--- a/tests/multiprocess/test_sqlite_try_acquire_promptness.py
+++ b/tests/multiprocess/test_sqlite_try_acquire_promptness.py
@@ -1,0 +1,67 @@
+"""SQLite cross-process nonblocking-acquire promptness regression."""
+
+from __future__ import annotations
+
+import multiprocessing
+
+import pytest
+
+from tests.multiprocess._harness import (
+    ChildHandle,
+    LimiterSpec,
+    finish_child,
+    receive_event,
+    scaled,
+    spawn_child,
+    terminate_children,
+)
+
+PROBE_COUNT = 3
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "pending SQLite per-operation busy_timeout fix for spec-review M1; "
+        "remove this mark after re-merging the engine fix"
+    ),
+)
+def test_sqlite_try_acquire_returns_promptly_while_writer_holds_lock(
+    sqlite_backend_case,
+) -> None:
+    """Require timeout=0 calls to return without inheriting the 5s busy timeout."""
+    limiter_spec = LimiterSpec(limit=4, per_seconds=60)
+    context = multiprocessing.get_context("spawn")
+    release_gate = context.Event()
+    holder = spawn_child(
+        "hold_sqlite_write_transaction",
+        sqlite_backend_case.spec,
+        limiter_spec,
+        release_gate=release_gate,
+    )
+    children: list[ChildHandle] = [holder]
+    results: list[dict[str, object]] = []
+    try:
+        receive_event(holder, "write_locked", timeout=scaled(15))
+        probes = [
+            spawn_child(
+                "timed_try_acquire",
+                sqlite_backend_case.spec,
+                limiter_spec,
+                amount=1,
+            )
+            for _ in range(PROBE_COUNT)
+        ]
+        children.extend(probes)
+        results = [finish_child(probe, timeout=scaled(10)) for probe in probes]
+    finally:
+        release_gate.set()
+        if holder.process.is_alive():
+            finish_child(holder, timeout=scaled(5))
+        terminate_children(children)
+
+    prompt_bound = scaled(1)
+    assert all(
+        result["outcome"] in {"acquired", "TimeoutError"} for result in results
+    ), results
+    assert all(float(result["elapsed"]) < prompt_bound for result in results), results

--- a/tests/multiprocess/test_sqlite_try_acquire_promptness.py
+++ b/tests/multiprocess/test_sqlite_try_acquire_promptness.py
@@ -65,7 +65,8 @@ def test_sqlite_try_acquire_returns_promptly_while_writer_holds_lock(
             terminate_children(children)
 
     prompt_bound = scaled(1)
-    assert all(
-        result["outcome"] in {"acquired", "TimeoutError"} for result in results
-    ), results
+    # The holder's write lock is confirmed held (write_locked event), so a probe
+    # that "acquired" would mean broken setup passing silently; only a prompt
+    # TimeoutError proves the try-acquire contract under contention.
+    assert all(result["outcome"] == "TimeoutError" for result in results), results
     assert all(float(result["elapsed"]) < prompt_bound for result in results), results

--- a/tests/multiprocess/test_sqlite_try_acquire_promptness.py
+++ b/tests/multiprocess/test_sqlite_try_acquire_promptness.py
@@ -25,38 +25,44 @@ def test_sqlite_try_acquire_returns_promptly_while_writer_holds_lock(
     context = multiprocessing.get_context("spawn")
     release_gate = context.Event()
     probe_gate = context.Event()
-    probes = [
-        spawn_child(
-            "timed_try_acquire",
-            sqlite_backend_case.spec,
-            limiter_spec,
-            amount=1,
-            start_gate=probe_gate,
-        )
-        for _ in range(PROBE_COUNT)
-    ]
-    children: list[ChildHandle] = list(probes)
-    for probe in probes:
-        receive_event(probe, "ready", timeout=scaled(15))
-
-    holder = spawn_child(
-        "hold_sqlite_write_transaction",
-        sqlite_backend_case.spec,
-        limiter_spec,
-        release_gate=release_gate,
-    )
-    children.append(holder)
+    probes: list[ChildHandle] = []
+    children: list[ChildHandle] = []
+    holder: ChildHandle | None = None
     results: list[dict[str, object]] = []
     try:
+        # Initialize one probe at a time. Concurrent timeout=0 preflights can
+        # legitimately contend with each other before the injected lock exists,
+        # which would test setup rather than operation promptness.
+        for _ in range(PROBE_COUNT):
+            probe = spawn_child(
+                "timed_try_acquire",
+                sqlite_backend_case.spec,
+                limiter_spec,
+                amount=1,
+                start_gate=probe_gate,
+            )
+            probes.append(probe)
+            children.append(probe)
+            receive_event(probe, "ready", timeout=scaled(15))
+
+        holder = spawn_child(
+            "hold_sqlite_write_transaction",
+            sqlite_backend_case.spec,
+            limiter_spec,
+            release_gate=release_gate,
+        )
+        children.append(holder)
         receive_event(holder, "write_locked", timeout=scaled(15))
         probe_gate.set()
         results = [finish_child(probe, timeout=scaled(10)) for probe in probes]
     finally:
         probe_gate.set()
         release_gate.set()
-        if holder.process.is_alive():
-            finish_child(holder, timeout=scaled(5))
-        terminate_children(children)
+        try:
+            if holder is not None and holder.process.is_alive():
+                finish_child(holder, timeout=scaled(5))
+        finally:
+            terminate_children(children)
 
     prompt_bound = scaled(1)
     assert all(

--- a/tests/multiprocess/test_sqlite_try_acquire_promptness.py
+++ b/tests/multiprocess/test_sqlite_try_acquire_promptness.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import multiprocessing
 
-import pytest
-
 from tests.multiprocess._harness import (
     ChildHandle,
     LimiterSpec,
@@ -19,13 +17,6 @@ from tests.multiprocess._harness import (
 PROBE_COUNT = 3
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "pending SQLite per-operation busy_timeout fix for spec-review M1; "
-        "remove this mark after re-merging the engine fix"
-    ),
-)
 def test_sqlite_try_acquire_returns_promptly_while_writer_holds_lock(
     sqlite_backend_case,
 ) -> None:

--- a/tests/unit/test_sqlite_async_backend.py
+++ b/tests/unit/test_sqlite_async_backend.py
@@ -18,10 +18,12 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _config(*, limit: float = 10.0, per_seconds: int = 10) -> PerModelConfig:
+def _config(
+    *, metric: str = "requests", limit: float = 10.0, per_seconds: int = 10
+) -> PerModelConfig:
     return PerModelConfig(
         quotas=UsageQuotas(
-            [Quota(metric="requests", limit=limit, per_seconds=per_seconds)]
+            [Quota(metric=metric, limit=limit, per_seconds=per_seconds)]
         ),
         model_family="async-sqlite-tests",
     )
@@ -115,3 +117,30 @@ async def test_async_sqlite_builder_aclose_is_idempotent(tmp_path: Path) -> None
     builder.build(_config())
     await builder.aclose()
     await builder.aclose()
+
+
+async def test_async_sqlite_metric_rebuilds_bound_worker_threads_and_registry(
+    tmp_path: Path,
+) -> None:
+    builder = SqliteBackendBuilder(
+        tmp_path / "async-rebuild-lifecycle.sqlite3",
+        key_prefix="rebuilds",
+    )
+    current = builder.build(_config(metric="requests"))
+    baseline_workers = sum(
+        thread.name.startswith("token-throttle-sqlite")
+        for thread in threading.enumerate()
+    )
+    try:
+        for index in range(10):
+            cfg = _config(metric="tokens" if index % 2 == 0 else "requests")
+            replacement = builder.build(cfg)
+            current = await current.prepare_reconfigured_backend(replacement, cfg)
+            assert len(builder._backends) == 1
+            live_workers = sum(
+                thread.name.startswith("token-throttle-sqlite")
+                for thread in threading.enumerate()
+            )
+            assert live_workers <= baseline_workers + 1
+    finally:
+        await builder.aclose()

--- a/tests/unit/test_sqlite_async_backend.py
+++ b/tests/unit/test_sqlite_async_backend.py
@@ -7,8 +7,10 @@ from typing import TYPE_CHECKING
 import pytest
 
 from token_throttle import (
+    DuplicateRefundError,
     PerModelConfig,
     Quota,
+    RateLimiterCallbacks,
     SqliteBackendBuilder,
     UsageQuotas,
     frozen_usage,
@@ -106,6 +108,279 @@ async def test_async_sqlite_cancelled_committed_acquire_is_refunded(
         assert await backend.await_for_capacity(usage, timeout=0) is not None
     finally:
         release_result.set()
+        await builder.aclose()
+
+
+async def test_async_sqlite_cancel_during_consumed_callback_cleans_acquire(
+    tmp_path: Path,
+) -> None:
+    callback_entered = asyncio.Event()
+
+    async def block_consumed_callback(**_kwargs) -> None:
+        callback_entered.set()
+        await asyncio.Event().wait()
+
+    builder = SqliteBackendBuilder(
+        tmp_path / "cancelled-callback.sqlite3",
+        key_prefix="async-tests",
+    )
+    backend = builder.build(
+        _config(),
+        callbacks=RateLimiterCallbacks(on_capacity_consumed=block_consumed_callback),
+    )
+    usage = frozen_usage({"requests": 4})
+    task = asyncio.create_task(
+        backend.await_for_capacity(
+            usage,
+            timeout=1,
+            reservation_id="callback-cancel",
+            reservation_lifetime_seconds=20.0,
+        )
+    )
+    try:
+        await asyncio.wait_for(callback_entered.wait(), timeout=2)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        snapshots, counts = await backend._run_engine(backend._engine.inspect_snapshot)
+        assert snapshots[0].current_capacity == pytest.approx(10.0)
+        assert counts["acquire_markers"] == 0
+    finally:
+        task.cancel()
+        await builder.aclose()
+
+
+async def test_async_sqlite_ordinary_callback_error_preserves_acquire(
+    tmp_path: Path,
+) -> None:
+    async def raise_from_callback(**_kwargs) -> None:
+        raise RuntimeError("callback failed")
+
+    builder = SqliteBackendBuilder(
+        tmp_path / "ordinary-callback-error.sqlite3",
+        key_prefix="async-tests",
+    )
+    backend = builder.build(
+        _config(),
+        callbacks=RateLimiterCallbacks(on_capacity_consumed=raise_from_callback),
+    )
+    usage = frozen_usage({"requests": 4})
+    try:
+        with pytest.warns(RuntimeWarning, match="callback failed"):
+            acquired_at = await backend.await_for_capacity(
+                usage,
+                timeout=1,
+                reservation_id="callback-error",
+                reservation_lifetime_seconds=20.0,
+            )
+        assert acquired_at is not None
+        snapshots, counts = await backend._run_engine(backend._engine.inspect_snapshot)
+        assert snapshots[0].current_capacity == pytest.approx(6.0, abs=0.1)
+        assert counts["acquire_markers"] == 1
+    finally:
+        await builder.aclose()
+
+
+async def test_async_sqlite_repeated_cancellation_cleans_committed_acquire(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = SqliteBackendBuilder(
+        tmp_path / "repeated-cancel.sqlite3",
+        key_prefix="async-tests",
+    )
+    backend = builder.build(_config())
+    committed = threading.Event()
+    release_result = threading.Event()
+    original_try_consume = backend._engine.try_consume
+
+    def pause_after_commit(*args, **kwargs):
+        result = original_try_consume(*args, **kwargs)
+        if result.available:
+            committed.set()
+            if not release_result.wait(timeout=5):
+                raise RuntimeError("test did not release committed SQLite attempt")
+        return result
+
+    monkeypatch.setattr(backend._engine, "try_consume", pause_after_commit)
+    usage = frozen_usage({"requests": 4})
+    task = asyncio.create_task(
+        backend.await_for_capacity(
+            usage,
+            timeout=1,
+            reservation_id="repeated-cancel",
+            reservation_lifetime_seconds=20.0,
+        )
+    )
+    try:
+        assert await asyncio.to_thread(committed.wait, 2)
+        for _ in range(200):
+            task.cancel()
+            await asyncio.sleep(0)
+        release_result.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        snapshots, counts = await backend._run_engine(backend._engine.inspect_snapshot)
+        assert snapshots[0].current_capacity == pytest.approx(10.0)
+        assert counts["acquire_markers"] == 0
+    finally:
+        release_result.set()
+        task.cancel()
+        await builder.aclose()
+
+
+async def test_async_sqlite_cancel_during_cleanup_still_lands_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback_entered = asyncio.Event()
+
+    async def block_consumed_callback(**_kwargs) -> None:
+        callback_entered.set()
+        await asyncio.Event().wait()
+
+    builder = SqliteBackendBuilder(
+        tmp_path / "cancel-during-cleanup.sqlite3",
+        key_prefix="async-tests",
+    )
+    backend = builder.build(
+        _config(),
+        callbacks=RateLimiterCallbacks(on_capacity_consumed=block_consumed_callback),
+    )
+    cleanup_committed = threading.Event()
+    release_cleanup = threading.Event()
+    original_cleanup = backend._engine.cleanup_consumption
+
+    def pause_after_cleanup(*args, **kwargs):
+        result = original_cleanup(*args, **kwargs)
+        cleanup_committed.set()
+        if not release_cleanup.wait(timeout=5):
+            raise RuntimeError("test did not release SQLite cleanup")
+        return result
+
+    monkeypatch.setattr(backend._engine, "cleanup_consumption", pause_after_cleanup)
+    usage = frozen_usage({"requests": 4})
+    task = asyncio.create_task(
+        backend.await_for_capacity(
+            usage,
+            timeout=1,
+            reservation_id="cleanup-cancel",
+            reservation_lifetime_seconds=20.0,
+        )
+    )
+    try:
+        await asyncio.wait_for(callback_entered.wait(), timeout=2)
+        task.cancel()
+        assert await asyncio.to_thread(cleanup_committed.wait, 2)
+        task.cancel()
+        release_cleanup.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        snapshots, counts = await backend._run_engine(backend._engine.inspect_snapshot)
+        assert snapshots[0].current_capacity == pytest.approx(10.0)
+        assert counts["acquire_markers"] == 0
+    finally:
+        release_cleanup.set()
+        task.cancel()
+        await builder.aclose()
+
+
+async def test_async_sqlite_cancel_during_refund_lands_tombstone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = SqliteBackendBuilder(
+        tmp_path / "cancel-during-refund.sqlite3",
+        key_prefix="async-tests",
+    )
+    backend = builder.build(_config())
+    usage = frozen_usage({"requests": 4})
+    bucket_ids = frozenset({("requests", 10)})
+    await backend.await_for_capacity(
+        usage,
+        timeout=1,
+        reservation_id="refund-cancel",
+        reservation_lifetime_seconds=20.0,
+    )
+    refund_committed = threading.Event()
+    release_refund = threading.Event()
+    original_refund = backend._engine.refund
+
+    def pause_after_refund(*args, **kwargs):
+        result = original_refund(*args, **kwargs)
+        refund_committed.set()
+        if not release_refund.wait(timeout=5):
+            raise RuntimeError("test did not release SQLite refund")
+        return result
+
+    monkeypatch.setattr(backend._engine, "refund", pause_after_refund)
+
+    async def refund() -> bool:
+        return await backend.refund_capacity_for_buckets(
+            usage,
+            frozen_usage({"requests": 1}),
+            bucket_ids=bucket_ids,
+            reservation_id="refund-cancel",
+            reservation_model_family="async-sqlite-tests",
+            reservation_bucket_ids=bucket_ids,
+            reservation_reserved_usage=usage,
+        )
+
+    task = asyncio.create_task(refund())
+    try:
+        assert await asyncio.to_thread(refund_committed.wait, 2)
+        task.cancel()
+        release_refund.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        _, counts = await backend._run_engine(backend._engine.inspect_snapshot)
+        assert counts["acquire_markers"] == 0
+        assert counts["refund_tombstones"] == 1
+        with pytest.raises(DuplicateRefundError) as duplicate:
+            await refund()
+        assert duplicate.value.reason == "already_refunded"
+    finally:
+        release_refund.set()
+        task.cancel()
+        await builder.aclose()
+
+
+async def test_async_sqlite_waiter_is_visible_before_wait_callback(
+    tmp_path: Path,
+) -> None:
+    seen_waiters = []
+    seen_waiter_keys = []
+    backend_holder = []
+    usage = frozen_usage({"requests": 1})
+
+    async def on_wait_start(**_kwargs) -> None:
+        backend = backend_holder[0]
+        seen_waiter_keys.extend(backend._diagnostic_waiters)
+        diagnostic = await backend.introspect()
+        seen_waiters.extend(diagnostic.waits)
+        await backend.refund_capacity(usage, frozen_usage({"requests": 0}))
+
+    builder = SqliteBackendBuilder(
+        tmp_path / "waiter-parity.sqlite3",
+        key_prefix="async-tests",
+    )
+    backend = builder.build(
+        _config(limit=1.0),
+        callbacks=RateLimiterCallbacks(on_wait_start=on_wait_start),
+    )
+    backend_holder.append(backend)
+    try:
+        await backend.consume_capacity(usage)
+        await backend.await_for_capacity(
+            usage,
+            timeout=1,
+            reservation_id="visible-reservation",
+            reservation_lifetime_seconds=20.0,
+        )
+        assert len(seen_waiters) == 1
+        assert seen_waiters[0].reservation_id == "visible-reservation"
+        assert seen_waiter_keys != ["visible-reservation"]
+    finally:
         await builder.aclose()
 
 

--- a/tests/unit/test_sqlite_async_backend.py
+++ b/tests/unit/test_sqlite_async_backend.py
@@ -9,7 +9,9 @@ import pytest
 from token_throttle import (
     PerModelConfig,
     Quota,
+    RateLimiter,
     SqliteBackendBuilder,
+    SqliteBackendHealthDiagnostic,
     UsageQuotas,
     frozen_usage,
 )
@@ -100,11 +102,51 @@ async def test_async_sqlite_cancelled_committed_acquire_is_refunded(
             await task
 
         diagnostic = await backend.introspect()
-        assert any("acquire_markers=0" in issue.message for issue in diagnostic.issues)
+        assert diagnostic.sqlite_health is not None
+        assert diagnostic.sqlite_health.acquire_marker_count == 0
         assert await backend.await_for_capacity(usage, timeout=0) is not None
     finally:
         release_result.set()
         await builder.aclose()
+
+
+async def test_async_sqlite_limiter_reports_first_class_health_and_local_estimates(
+    tmp_path: Path,
+) -> None:
+    builder = SqliteBackendBuilder(
+        tmp_path / "limiter-diagnostics.sqlite3",
+        key_prefix="limiter-diagnostics",
+    )
+    async with RateLimiter(_config(), backend=builder) as limiter:
+        reservation = await limiter.acquire_capacity(
+            {"requests": 1},
+            model="sqlite-model",
+        )
+
+        assert limiter.snapshot_state() == {
+            "in_flight_reservations": 1,
+            "model_families": 1,
+            "backend_type": "sqlite",
+            "marker_count_estimate": 1,
+            "refund_dedup_count_estimate": 0,
+        }
+        diagnostic = await limiter.diagnose()
+        assert diagnostic.backend_type == "sqlite"
+        assert diagnostic.backend_health.sqlite == SqliteBackendHealthDiagnostic(
+            model_family_count=1,
+            bucket_count=1,
+            acquire_marker_count=1,
+            refund_tombstone_count=0,
+        )
+        assert diagnostic.backend_health.custom is None
+
+        await limiter.refund_capacity({"requests": 1}, reservation)
+        assert limiter.snapshot_state()["marker_count_estimate"] == 0
+        assert limiter.snapshot_state()["refund_dedup_count_estimate"] == 1
+        refunded_health = (await limiter.diagnose()).backend_health.sqlite
+        assert refunded_health is not None
+        assert refunded_health.acquire_marker_count == 0
+        assert refunded_health.refund_tombstone_count == 1
 
 
 async def test_async_sqlite_builder_aclose_is_idempotent(tmp_path: Path) -> None:

--- a/tests/unit/test_sqlite_async_backend.py
+++ b/tests/unit/test_sqlite_async_backend.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+from token_throttle import (
+    PerModelConfig,
+    Quota,
+    SqliteBackendBuilder,
+    UsageQuotas,
+    frozen_usage,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _config(*, limit: float = 10.0, per_seconds: int = 10) -> PerModelConfig:
+    return PerModelConfig(
+        quotas=UsageQuotas(
+            [Quota(metric="requests", limit=limit, per_seconds=per_seconds)]
+        ),
+        model_family="async-sqlite-tests",
+    )
+
+
+async def test_async_sqlite_backend_confines_engine_calls_to_one_worker_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = SqliteBackendBuilder(
+        tmp_path / "thread-confinement.sqlite3",
+        key_prefix="async-tests",
+    )
+    backend = builder.build(_config())
+    main_thread = threading.get_ident()
+    worker_threads: list[int] = []
+    original_consume = backend._engine.consume
+    original_snapshot = backend._engine.inspect_snapshot
+
+    def tracked_consume(*args, **kwargs):
+        worker_threads.append(threading.get_ident())
+        return original_consume(*args, **kwargs)
+
+    def tracked_snapshot(*args, **kwargs):
+        worker_threads.append(threading.get_ident())
+        return original_snapshot(*args, **kwargs)
+
+    monkeypatch.setattr(backend._engine, "consume", tracked_consume)
+    monkeypatch.setattr(backend._engine, "inspect_snapshot", tracked_snapshot)
+    try:
+        await backend.consume_capacity(frozen_usage({"requests": 1}))
+        diagnostic = await backend.introspect()
+        assert diagnostic.buckets[0].current_capacity is not None
+        assert len(set(worker_threads)) == 1
+        assert worker_threads[0] != main_thread
+    finally:
+        await builder.aclose()
+
+
+async def test_async_sqlite_cancelled_committed_acquire_is_refunded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    builder = SqliteBackendBuilder(
+        tmp_path / "cancelled-commit.sqlite3",
+        key_prefix="async-tests",
+    )
+    backend = builder.build(_config(limit=2.0))
+    committed = threading.Event()
+    release_result = threading.Event()
+    original_try_consume = backend._engine.try_consume
+
+    def pause_after_commit(*args, **kwargs):
+        result = original_try_consume(*args, **kwargs)
+        if result.available:
+            committed.set()
+            if not release_result.wait(timeout=5):
+                raise RuntimeError("test did not release committed SQLite attempt")
+        return result
+
+    monkeypatch.setattr(backend._engine, "try_consume", pause_after_commit)
+    usage = frozen_usage({"requests": 2})
+    task = asyncio.create_task(
+        backend.await_for_capacity(
+            usage,
+            timeout=1,
+            reservation_id="cancelled-reservation",
+            reservation_lifetime_seconds=20.0,
+        )
+    )
+    try:
+        assert await asyncio.to_thread(committed.wait, 2)
+        task.cancel()
+        release_result.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        diagnostic = await backend.introspect()
+        assert any("acquire_markers=0" in issue.message for issue in diagnostic.issues)
+        assert await backend.await_for_capacity(usage, timeout=0) is not None
+    finally:
+        release_result.set()
+        await builder.aclose()
+
+
+async def test_async_sqlite_builder_aclose_is_idempotent(tmp_path: Path) -> None:
+    builder = SqliteBackendBuilder(
+        tmp_path / "close.sqlite3",
+        key_prefix="async-tests",
+    )
+    builder.build(_config())
+    await builder.aclose()
+    await builder.aclose()

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -20,6 +20,8 @@ from token_throttle import (
     UsageQuotas,
     frozen_usage,
 )
+from token_throttle import _capacity as capacity_module
+from token_throttle._capacity import calculate_capacity
 from token_throttle._limiter_backends._sqlite import _engine as engine_module
 from token_throttle._limiter_backends._sqlite._engine import (
     SCHEMA_VERSION,
@@ -56,6 +58,7 @@ def _engine(  # noqa: PLR0913
     bucket_ttl_seconds: int = 100,
     refund_dedup_ttl_seconds: int = 100,
     max_reservation_lifetime_seconds: float = 20.0,
+    override_ttl_seconds: int = 100,
     prune_batch_size: int = 256,
     initialized_at: float = 100.0,
 ) -> SqliteEngine:
@@ -72,6 +75,7 @@ def _engine(  # noqa: PLR0913
         ),
         bucket_ttl_seconds=bucket_ttl_seconds,
         refund_dedup_ttl_seconds=refund_dedup_ttl_seconds,
+        override_ttl_seconds=override_ttl_seconds,
         max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
         prune_batch_size=prune_batch_size,
     )
@@ -470,6 +474,238 @@ def test_sqlite_set_max_capacity_anchors_elapsed_time_at_old_rate(
         assert refilled.result.pre_capacities[("requests", 10)] == 15.0
     finally:
         engine.close()
+
+
+def test_sqlite_configured_limits_remain_process_local(tmp_path: Path) -> None:
+    db_path = tmp_path / "local-config.sqlite3"
+    first = _engine(db_path, limit=10.0)
+    second = _engine(db_path, limit=20.0)
+    try:
+        first_result = first.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        second_result = second.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        first_again = first.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert first_result.result.max_capacities[("requests", 10)] == 10.0
+        assert second_result.result.max_capacities[("requests", 10)] == 20.0
+        assert first_again.result.max_capacities[("requests", 10)] == 10.0
+        with sqlite3.connect(db_path) as connection:
+            columns = {
+                row[1] for row in connection.execute("PRAGMA table_info(buckets)")
+            }
+        assert "max_capacity" not in columns
+        assert {"override_value", "override_expires_at"} <= columns
+    finally:
+        first.close()
+        second.close()
+
+
+def test_sqlite_override_is_cross_process_and_expires_to_local_config(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "override.sqlite3"
+    first = _engine(db_path, limit=10.0, override_ttl_seconds=2)
+    second = _engine(db_path, limit=20.0, override_ttl_seconds=2)
+    try:
+        first.set_max_capacity("requests", 10, 15.0, current_time=100.0)
+        active = second.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=101.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        expired = second.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=102.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert active.result.max_capacities[("requests", 10)] == 15.0
+        assert expired.result.max_capacities[("requests", 10)] == 20.0
+        with sqlite3.connect(db_path) as connection:
+            override = connection.execute(
+                "SELECT override_value, override_expires_at FROM buckets"
+            ).fetchone()
+        assert override == (None, None)
+    finally:
+        first.close()
+        second.close()
+
+
+def test_sqlite_config_after_restart_applies_without_rewriting_state(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "restart-config.sqlite3"
+    first = _engine(db_path, limit=10.0)
+    first.consume(
+        frozen_usage({"requests": 5}),
+        current_time=100.0,
+        reservation_id=None,
+        reservation_lifetime_seconds=None,
+    )
+    first.close()
+
+    restarted = _engine(db_path, limit=20.0, initialized_at=101.0)
+    try:
+        result = restarted.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=101.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert result.result.max_capacities[("requests", 10)] == 20.0
+        assert result.result.pre_capacities[("requests", 10)] == pytest.approx(7.0)
+    finally:
+        restarted.close()
+
+
+def test_sqlite_apply_configured_max_clears_override_and_anchors_state(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path / "apply-config.sqlite3")
+    try:
+        engine.consume(
+            frozen_usage({"requests": 10}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        engine.set_max_capacity("requests", 10, 20.0, current_time=105.0)
+        engine.apply_configured_max_capacity("requests", 10, 30.0, current_time=107.0)
+        result = engine.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=107.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert result.result.pre_capacities[("requests", 10)] == pytest.approx(9.0)
+        assert result.result.max_capacities[("requests", 10)] == 30.0
+        assert engine._connection.execute(
+            "SELECT override_value, override_expires_at FROM buckets"
+        ).fetchone() == (None, None)
+    finally:
+        engine.close()
+
+
+def test_sqlite_repairs_far_future_last_checked_on_failed_attempt(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path / "future-clock.sqlite3", bucket_ttl_seconds=10)
+    try:
+        engine._connection.execute(
+            "UPDATE buckets SET capacity = 0, last_checked = 1000, updated_at = 1000"
+        )
+        with pytest.warns(RuntimeWarning, match="Negative time_passed"):
+            failed = engine.try_consume(
+                frozen_usage({"requests": 1}),
+                current_time=200.0,
+                reservation_id=None,
+                reservation_lifetime_seconds=None,
+            )
+        assert failed.available is False
+        assert engine._connection.execute(
+            "SELECT capacity, last_checked, updated_at FROM buckets"
+        ).fetchone() == (0.0, 200.0, 200.0)
+        snapshots, _ = engine.inspect_snapshot(current_time=205.0)
+        assert snapshots[0].current_capacity == 5.0
+        pruned = engine.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=211.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert pruned.result.fresh_bucket_ids == (("requests", 10),)
+    finally:
+        engine.close()
+
+
+def test_sqlite_operation_sets_deadline_derived_busy_timeout(tmp_path: Path) -> None:
+    engine = _engine(tmp_path / "busy-timeout.sqlite3")
+    try:
+        engine.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+            busy_timeout_ms=123,
+        )
+        assert engine._connection.execute("PRAGMA busy_timeout").fetchone() == (123,)
+        engine.consume(
+            frozen_usage({"requests": 0}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert engine._connection.execute("PRAGMA busy_timeout").fetchone() == (5000,)
+    finally:
+        engine.close()
+
+
+def test_sqlite_clock_warning_includes_family_and_metric(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(capacity_module, "_backward_clock_warned", False)
+    monkeypatch.setattr(capacity_module, "_backward_clock_last_warning_at", None)
+    with pytest.warns(RuntimeWarning, match="Negative time_passed"):
+        calculate_capacity(
+            last_checked=101.0,
+            outdated_capacity=0.0,
+            current_time=100.0,
+            max_capacity=10.0,
+            rate_per_sec=1.0,
+            bucket_id="sqlite:clock-family:requests:10",
+        )
+    record = next(
+        record for record in caplog.records if "Negative time_passed" in record.message
+    )
+    assert record.token_throttle_model_family == "clock-family"  # noqa: S105
+    assert record.token_throttle_metric == "requests"  # noqa: S105
+
+
+def test_sync_sqlite_introspection_reports_live_state_and_durable_counts(
+    tmp_path: Path,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        tmp_path / "introspection.sqlite3",
+        key_prefix="introspection",
+    )
+    backend = builder.build(_config(limit=10.0))
+    try:
+        usage = frozen_usage({"requests": 4})
+        backend.consume_capacity(
+            usage,
+            reservation_id="introspection-marker",
+            reservation_lifetime_seconds=20.0,
+        )
+        backend.set_max_capacity("requests", 10, 15.0)
+        diagnostic = backend.introspect()
+        assert diagnostic.backend_type == "custom"
+        assert len(diagnostic.buckets) == 1
+        bucket = diagnostic.buckets[0]
+        assert bucket.metric == "requests"
+        assert bucket.configured_limit == 10.0
+        assert bucket.effective_max_capacity == 15.0
+        assert bucket.override_source == "backend"
+        assert bucket.current_capacity is not None
+        assert bucket.current_capacity < 10.0
+        assert diagnostic.waits == ()
+        assert any("acquire_markers=1" in issue.message for issue in diagnostic.issues)
+    finally:
+        builder.close()
 
 
 def test_sqlite_key_prefixes_isolate_capacity_in_one_database(

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -6,6 +6,7 @@ import os
 import sqlite3
 import threading
 import time
+import warnings
 from typing import TYPE_CHECKING
 
 import pytest
@@ -82,7 +83,7 @@ def _engine(  # noqa: PLR0913
         max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
         prune_batch_size=prune_batch_size,
     )
-    engine.initialize_buckets(initialized_at)
+    engine.initialize_buckets(lambda: initialized_at)
     return engine
 
 
@@ -109,6 +110,35 @@ def _acquire_in_process(
         result_queue.put(("error", type(exc).__name__))
     else:
         result_queue.put(("acquired", reservation_id))
+    finally:
+        builder.close()
+
+
+def _consume_loop_in_process(
+    db_path: str,
+    key_prefix: str,
+    iterations: int,
+    result_queue,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        db_path,
+        key_prefix=key_prefix,
+        busy_timeout_ms=5000,
+    )
+    try:
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always", RuntimeWarning)
+            backend = builder.build(_config(limit=1000.0, per_seconds=60))
+            for _ in range(iterations):
+                backend.consume_capacity(frozen_usage({"requests": 0}))
+        result_queue.put(
+            (
+                "ok",
+                sum("Negative time_passed" in str(item.message) for item in captured),
+            )
+        )
+    except Exception as exc:
+        result_queue.put(("error", type(exc).__name__))
     finally:
         builder.close()
 
@@ -172,13 +202,13 @@ def test_sqlite_engine_refill_calls_shared_capacity_math(
     try:
         engine.consume(
             frozen_usage({"requests": 10}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         result = engine.try_consume(
             frozen_usage({"requests": 5}),
-            current_time=105.0,
+            clock=lambda: 105.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -190,6 +220,70 @@ def test_sqlite_engine_refill_calls_shared_capacity_math(
         engine.close()
 
 
+def test_sqlite_engine_samples_clock_after_acquiring_write_lock(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "under-lock-clock.sqlite3"
+    engine = _engine(db_path)
+    holder = sqlite3.connect(db_path, isolation_level=None)
+    started = threading.Event()
+    clock_called = threading.Event()
+    calls = 0
+
+    def clock() -> float:
+        nonlocal calls
+        calls += 1
+        clock_called.set()
+        return 101.0
+
+    def consume() -> None:
+        started.set()
+        engine.consume(
+            frozen_usage({"requests": 0}),
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+            clock=clock,
+        )
+
+    holder.execute("BEGIN IMMEDIATE")
+    thread = threading.Thread(target=consume)
+    thread.start()
+    try:
+        assert started.wait(timeout=1)
+        assert not clock_called.wait(timeout=0.1)
+        holder.execute("COMMIT")
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+        assert calls == 1
+    finally:
+        if holder.in_transaction:
+            holder.execute("ROLLBACK")
+        holder.close()
+        engine.close()
+
+
+def test_sqlite_multiprocess_contention_has_no_spurious_backward_clock_warnings(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "contention-clock.sqlite3"
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_consume_loop_in_process,
+            args=(str(db_path), "clock-contention", 60, result_queue),
+        )
+        for _ in range(8)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+    results = [result_queue.get(timeout=1) for _ in processes]
+    assert results == [("ok", 0)] * len(processes)
+
+
 def test_sqlite_marker_refund_and_tombstone_are_one_lifecycle(
     tmp_path: Path,
 ) -> None:
@@ -199,7 +293,7 @@ def test_sqlite_marker_refund_and_tombstone_are_one_lifecycle(
     try:
         engine.try_consume(
             reservation_usage,
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id="reservation-1",
             reservation_lifetime_seconds=20.0,
         )
@@ -212,7 +306,7 @@ def test_sqlite_marker_refund_and_tombstone_are_one_lifecycle(
             reservation_usage,
             frozen_usage({"requests": 1}),
             refund_bucket_ids=bucket_ids,
-            current_time=101.0,
+            clock=lambda: 101.0,
             reservation_id="reservation-1",
             reservation_model_family="sqlite-tests",
             reservation_bucket_ids=bucket_ids,
@@ -234,7 +328,7 @@ def test_sqlite_marker_refund_and_tombstone_are_one_lifecycle(
                 reservation_usage,
                 frozen_usage({"requests": 1}),
                 refund_bucket_ids=bucket_ids,
-                current_time=102.0,
+                clock=lambda: 102.0,
                 reservation_id="reservation-1",
                 reservation_model_family="sqlite-tests",
                 reservation_bucket_ids=bucket_ids,
@@ -252,7 +346,7 @@ def test_sqlite_unknown_marker_does_not_credit_capacity(tmp_path: Path) -> None:
     try:
         engine.consume(
             usage,
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -261,7 +355,7 @@ def test_sqlite_unknown_marker_does_not_credit_capacity(tmp_path: Path) -> None:
                 usage,
                 frozen_usage({"requests": 0}),
                 refund_bucket_ids=bucket_ids,
-                current_time=100.0,
+                clock=lambda: 100.0,
                 reservation_id="missing",
                 reservation_model_family="sqlite-tests",
                 reservation_bucket_ids=bucket_ids,
@@ -269,7 +363,7 @@ def test_sqlite_unknown_marker_does_not_credit_capacity(tmp_path: Path) -> None:
             )
         remaining = engine.try_consume(
             usage,
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -298,7 +392,7 @@ def test_sqlite_pruning_is_bounded_per_table(tmp_path: Path) -> None:
             )
         engine.consume(
             frozen_usage({"requests": 0}),
-            current_time=10.0,
+            clock=lambda: 10.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -320,7 +414,7 @@ def test_sqlite_expired_target_marker_is_rejected_beyond_prune_batch(
     try:
         engine.consume(
             usage,
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id="target-expired-marker",
             reservation_lifetime_seconds=1.0,
         )
@@ -333,7 +427,7 @@ def test_sqlite_expired_target_marker_is_rejected_beyond_prune_batch(
                 usage,
                 frozen_usage({"requests": 0}),
                 refund_bucket_ids=bucket_ids,
-                current_time=102.0,
+                clock=lambda: 102.0,
                 reservation_id="target-expired-marker",
                 reservation_model_family="sqlite-tests",
                 reservation_bucket_ids=bucket_ids,
@@ -341,7 +435,7 @@ def test_sqlite_expired_target_marker_is_rejected_beyond_prune_batch(
             )
         unavailable = engine.try_consume(
             frozen_usage({"requests": 9}),
-            current_time=102.0,
+            clock=lambda: 102.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -363,7 +457,7 @@ def test_sqlite_expired_target_tombstone_allows_id_reuse_beyond_prune_batch(
     try:
         engine.consume(
             usage,
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id="reusable-id",
             reservation_lifetime_seconds=20.0,
         )
@@ -371,7 +465,7 @@ def test_sqlite_expired_target_tombstone_allows_id_reuse_beyond_prune_batch(
             usage,
             usage,
             refund_bucket_ids=bucket_ids,
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id="reusable-id",
             reservation_model_family="sqlite-tests",
             reservation_bucket_ids=bucket_ids,
@@ -383,7 +477,7 @@ def test_sqlite_expired_target_tombstone_allows_id_reuse_beyond_prune_batch(
         )
         reused = engine.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=103.0,
+            clock=lambda: 103.0,
             reservation_id="reusable-id",
             reservation_lifetime_seconds=20.0,
         )
@@ -402,13 +496,13 @@ def test_sqlite_bucket_ttl_pruning_restores_only_fresh_capacity(
     try:
         engine.consume(
             frozen_usage({"requests": 10}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         result = engine.consume(
             frozen_usage({"requests": 1}),
-            current_time=111.0,
+            clock=lambda: 111.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -427,7 +521,7 @@ def test_sqlite_negative_refund_preserves_debt_for_linear_refill(
     try:
         engine.consume(
             frozen_usage({"requests": 10}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -435,7 +529,7 @@ def test_sqlite_negative_refund_preserves_debt_for_linear_refill(
             frozen_usage({"requests": 2}),
             frozen_usage({"requests": 20}),
             refund_bucket_ids=bucket_ids,
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_model_family=None,
             reservation_bucket_ids=None,
@@ -444,7 +538,7 @@ def test_sqlite_negative_refund_preserves_debt_for_linear_refill(
         assert refunded.post_capacities[("requests", 10)] == -10.0
         halfway = engine.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=105.0,
+            clock=lambda: 105.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -460,21 +554,21 @@ def test_sqlite_set_max_capacity_anchors_elapsed_time_at_old_rate(
     try:
         engine.consume(
             frozen_usage({"requests": 10}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
-        engine.set_max_capacity("requests", 10, 20.0, current_time=105.0)
+        engine.set_max_capacity("requests", 10, 20.0, clock=lambda: 105.0)
         anchored = engine.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=105.0,
+            clock=lambda: 105.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         assert anchored.result.pre_capacities[("requests", 10)] == 5.0
         refilled = engine.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=110.0,
+            clock=lambda: 110.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -490,19 +584,19 @@ def test_sqlite_configured_limits_remain_process_local(tmp_path: Path) -> None:
     try:
         first_result = first.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         second_result = second.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         first_again = first.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -527,16 +621,16 @@ def test_sqlite_override_is_cross_process_and_expires_to_local_config(
     first = _engine(db_path, limit=10.0, override_ttl_seconds=2)
     second = _engine(db_path, limit=20.0, override_ttl_seconds=2)
     try:
-        first.set_max_capacity("requests", 10, 15.0, current_time=100.0)
+        first.set_max_capacity("requests", 10, 15.0, clock=lambda: 100.0)
         active = second.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=101.0,
+            clock=lambda: 101.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         expired = second.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=102.0,
+            clock=lambda: 102.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -559,7 +653,7 @@ def test_sqlite_config_after_restart_applies_without_rewriting_state(
     first = _engine(db_path, limit=10.0)
     first.consume(
         frozen_usage({"requests": 5}),
-        current_time=100.0,
+        clock=lambda: 100.0,
         reservation_id=None,
         reservation_lifetime_seconds=None,
     )
@@ -569,7 +663,7 @@ def test_sqlite_config_after_restart_applies_without_rewriting_state(
     try:
         result = restarted.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=101.0,
+            clock=lambda: 101.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -586,15 +680,15 @@ def test_sqlite_apply_configured_max_clears_override_and_anchors_state(
     try:
         engine.consume(
             frozen_usage({"requests": 10}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
-        engine.set_max_capacity("requests", 10, 20.0, current_time=105.0)
-        engine.apply_configured_max_capacity("requests", 10, 30.0, current_time=107.0)
+        engine.set_max_capacity("requests", 10, 20.0, clock=lambda: 105.0)
+        engine.apply_configured_max_capacity("requests", 10, 30.0, clock=lambda: 107.0)
         result = engine.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=107.0,
+            clock=lambda: 107.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -622,7 +716,7 @@ def test_sqlite_repairs_far_future_last_checked_on_failed_attempt(
         with pytest.warns(RuntimeWarning, match="Negative time_passed"):
             failed = engine.try_consume(
                 frozen_usage({"requests": 1}),
-                current_time=200.0,
+                clock=lambda: 200.0,
                 reservation_id=None,
                 reservation_lifetime_seconds=None,
             )
@@ -630,11 +724,11 @@ def test_sqlite_repairs_far_future_last_checked_on_failed_attempt(
         assert engine._connection.execute(
             "SELECT capacity, last_checked, updated_at FROM buckets"
         ).fetchone() == (0.0, 200.0, 200.0)
-        snapshots, _ = engine.inspect_snapshot(current_time=205.0)
+        snapshots, _ = engine.inspect_snapshot(clock=lambda: 205.0)
         assert snapshots[0].current_capacity == 5.0
         pruned = engine.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=211.0,
+            clock=lambda: 211.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -648,7 +742,7 @@ def test_sqlite_operation_sets_deadline_derived_busy_timeout(tmp_path: Path) -> 
     try:
         engine.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
             busy_timeout_ms=123,
@@ -656,7 +750,7 @@ def test_sqlite_operation_sets_deadline_derived_busy_timeout(tmp_path: Path) -> 
         assert engine._connection.execute("PRAGMA busy_timeout").fetchone() == (123,)
         engine.consume(
             frozen_usage({"requests": 0}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -788,13 +882,13 @@ def test_sqlite_key_prefixes_isolate_capacity_in_one_database(
     try:
         first.consume(
             frozen_usage({"requests": 2}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         second_result = second.try_consume(
             frozen_usage({"requests": 2}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -825,19 +919,19 @@ def test_sqlite_bucket_pruning_respects_each_rows_absolute_expiry(
     try:
         long_lived.consume(
             frozen_usage({"requests": 10}),
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         short_lived.consume(
             frozen_usage({"requests": 0}),
-            current_time=102.0,
+            clock=lambda: 102.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
         preserved = long_lived.try_consume(
             frozen_usage({"requests": 0}),
-            current_time=102.0,
+            clock=lambda: 102.0,
             reservation_id=None,
             reservation_lifetime_seconds=None,
         )
@@ -858,14 +952,14 @@ def test_sqlite_duplicate_acquire_is_visible_across_connections(
     try:
         first.consume(
             usage,
-            current_time=100.0,
+            clock=lambda: 100.0,
             reservation_id="shared-reservation",
             reservation_lifetime_seconds=20.0,
         )
         with pytest.raises(DuplicateRefundError) as duplicate:
             second.consume(
                 usage,
-                current_time=100.0,
+                clock=lambda: 100.0,
                 reservation_id="shared-reservation",
                 reservation_lifetime_seconds=20.0,
             )

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import multiprocessing
 import os
+import re
 import sqlite3
 import threading
 import time
@@ -1163,7 +1164,8 @@ def test_sqlite_missing_parent_error_names_resolved_path(tmp_path: Path) -> None
     resolved = os.path.realpath(db_path)
     builder = SyncSqliteBackendBuilder(db_path, key_prefix="scope")
     try:
-        with pytest.raises(sqlite3.OperationalError, match=resolved):
+        # match= is a regex; Windows paths contain backslash escapes like \U.
+        with pytest.raises(sqlite3.OperationalError, match=re.escape(resolved)):
             builder.build(_config())
     finally:
         builder.close()

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -4,6 +4,8 @@ import math
 import multiprocessing
 import os
 import sqlite3
+import threading
+import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -705,6 +707,43 @@ def test_sync_sqlite_introspection_reports_live_state_and_durable_counts(
         assert diagnostic.waits == ()
         assert any("acquire_markers=1" in issue.message for issue in diagnostic.issues)
     finally:
+        builder.close()
+
+
+def test_sync_sqlite_introspection_tracks_and_removes_waiters(tmp_path: Path) -> None:
+    builder = SyncSqliteBackendBuilder(
+        tmp_path / "waiter-introspection.sqlite3",
+        key_prefix="introspection",
+        sleep_interval=0.01,
+    )
+    backend = builder.build(_config(limit=1.0, per_seconds=100))
+    usage = frozen_usage({"requests": 1})
+    backend.consume_capacity(usage)
+    outcome: list[str] = []
+
+    def wait() -> None:
+        backend.wait_for_capacity(usage, timeout=2)
+        outcome.append("acquired")
+
+    thread = threading.Thread(target=wait)
+    thread.start()
+    try:
+        deadline = time.monotonic() + 1
+        diagnostic = backend.introspect()
+        while not diagnostic.waits and time.monotonic() < deadline:
+            time.sleep(0.01)
+            diagnostic = backend.introspect()
+        assert len(diagnostic.waits) == 1
+        assert diagnostic.waits[0].state == "waiting_for_capacity"
+        assert diagnostic.waits[0].blocked_buckets[0].metric == "requests"
+        backend.refund_capacity(usage, frozen_usage({"requests": 0}))
+        thread.join(timeout=1)
+        assert outcome == ["acquired"]
+        assert backend.introspect().waits == ()
+    finally:
+        if thread.is_alive():
+            backend.refund_capacity(usage, frozen_usage({"requests": 0}))
+            thread.join(timeout=1)
         builder.close()
 
 

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -132,6 +132,10 @@ def test_sqlite_engine_creates_versioned_wal_schema(tmp_path: Path) -> None:
         assert journal_mode == ("wal",)
         assert engine._connection.execute("PRAGMA synchronous").fetchone() == (1,)
         assert engine._connection.execute("PRAGMA busy_timeout").fetchone() == (5000,)
+        bucket_columns = {
+            row[1] for row in engine._connection.execute("PRAGMA table_info(buckets)")
+        }
+        assert "expires_at" in bucket_columns
     finally:
         engine.close()
 
@@ -611,7 +615,8 @@ def test_sqlite_repairs_far_future_last_checked_on_failed_attempt(
         monkeypatch.setattr(capacity_module, "_backward_clock_warned", False)
         monkeypatch.setattr(capacity_module, "_backward_clock_last_warning_at", None)
         engine._connection.execute(
-            "UPDATE buckets SET capacity = 0, last_checked = 1000, updated_at = 1000"
+            "UPDATE buckets SET capacity = 0, last_checked = 1000, "
+            "updated_at = 1000, expires_at = 2000"
         )
         with pytest.warns(RuntimeWarning, match="Negative time_passed"):
             failed = engine.try_consume(
@@ -773,6 +778,50 @@ def test_sqlite_key_prefixes_isolate_capacity_in_one_database(
     finally:
         first.close()
         second.close()
+
+
+def test_sqlite_bucket_pruning_respects_each_rows_absolute_expiry(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "heterogeneous-ttls.sqlite3"
+    long_lived = _engine(
+        db_path,
+        key_prefix="long-lived",
+        limit=10.0,
+        per_seconds=10,
+        bucket_ttl_seconds=100,
+    )
+    short_lived = _engine(
+        db_path,
+        key_prefix="short-lived",
+        limit=1.0,
+        per_seconds=1,
+        bucket_ttl_seconds=1,
+    )
+    try:
+        long_lived.consume(
+            frozen_usage({"requests": 10}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        short_lived.consume(
+            frozen_usage({"requests": 0}),
+            current_time=102.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        preserved = long_lived.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=102.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert preserved.result.fresh_bucket_ids == ()
+        assert preserved.result.pre_capacities[("requests", 10)] == 2.0
+    finally:
+        long_lived.close()
+        short_lived.close()
 
 
 def test_sqlite_duplicate_acquire_is_visible_across_connections(

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -1,0 +1,600 @@
+from __future__ import annotations
+
+import math
+import multiprocessing
+import os
+import sqlite3
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from token_throttle import (
+    DuplicateRefundError,
+    PerModelConfig,
+    Quota,
+    SyncSqliteBackendBuilder,
+    UnknownReservationError,
+    UsageQuotas,
+    frozen_usage,
+)
+from token_throttle._limiter_backends._sqlite import _engine as engine_module
+from token_throttle._limiter_backends._sqlite._engine import (
+    SCHEMA_VERSION,
+    BucketSpec,
+    SqliteEngine,
+)
+from token_throttle._limiter_backends._sqlite._ttl import (
+    derive_default_max_reservation_lifetime_seconds_from_ttls,
+    validate_reservation_lifetime_ttl_invariant,
+)
+
+
+def _config(
+    model_family: str = "sqlite-tests",
+    *,
+    limit: float = 10.0,
+    per_seconds: int = 10,
+) -> PerModelConfig:
+    return PerModelConfig(
+        quotas=UsageQuotas(
+            [Quota(metric="requests", limit=limit, per_seconds=per_seconds)]
+        ),
+        model_family=model_family,
+    )
+
+
+def _engine(  # noqa: PLR0913
+    db_path: Path,
+    *,
+    key_prefix: str = "tests",
+    model_family: str = "sqlite-tests",
+    limit: float = 10.0,
+    per_seconds: int = 10,
+    bucket_ttl_seconds: int = 100,
+    refund_dedup_ttl_seconds: int = 100,
+    max_reservation_lifetime_seconds: float = 20.0,
+    prune_batch_size: int = 256,
+    initialized_at: float = 100.0,
+) -> SqliteEngine:
+    engine = SqliteEngine(
+        db_path=str(db_path),
+        key_prefix=key_prefix,
+        model_family=model_family,
+        buckets=(
+            BucketSpec(
+                metric="requests",
+                per_seconds=per_seconds,
+                configured_max_capacity=limit,
+            ),
+        ),
+        bucket_ttl_seconds=bucket_ttl_seconds,
+        refund_dedup_ttl_seconds=refund_dedup_ttl_seconds,
+        max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
+        prune_batch_size=prune_batch_size,
+    )
+    engine.initialize_buckets(initialized_at)
+    return engine
+
+
+def _acquire_in_process(
+    db_path: str,
+    key_prefix: str,
+    reservation_id: str,
+    result_queue,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        db_path,
+        key_prefix=key_prefix,
+        busy_timeout_ms=2000,
+    )
+    try:
+        backend = builder.build(_config(limit=2.0))
+        backend.wait_for_capacity(
+            frozen_usage({"requests": 2}),
+            timeout=0,
+            reservation_id=reservation_id,
+            reservation_lifetime_seconds=20.0,
+        )
+    except Exception as exc:
+        result_queue.put(("error", type(exc).__name__))
+    else:
+        result_queue.put(("acquired", reservation_id))
+    finally:
+        builder.close()
+
+
+def test_sqlite_engine_creates_versioned_wal_schema(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.sqlite3"
+    engine = _engine(db_path)
+    try:
+        with sqlite3.connect(db_path) as connection:
+            tables = {
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            }
+            version = connection.execute(
+                "SELECT value FROM meta WHERE key = 'schema_version'"
+            ).fetchone()
+            journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
+        assert {"meta", "buckets", "acquire_markers", "refund_tombstones"} <= tables
+        assert version == (str(SCHEMA_VERSION),)
+        assert journal_mode == ("wal",)
+        assert engine._connection.execute("PRAGMA synchronous").fetchone() == (1,)
+        assert engine._connection.execute("PRAGMA busy_timeout").fetchone() == (5000,)
+    finally:
+        engine.close()
+
+
+def test_sqlite_engine_rejects_unknown_schema_version(tmp_path: Path) -> None:
+    db_path = tmp_path / "future.sqlite3"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        connection.execute(
+            "INSERT INTO meta(key, value) VALUES ('schema_version', '999')"
+        )
+
+    with pytest.raises(RuntimeError, match=r"Unsupported.*schema version '999'"):
+        _engine(db_path)
+
+
+def test_sqlite_engine_refill_calls_shared_capacity_math(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = _engine(tmp_path / "refill.sqlite3")
+    calls = 0
+    shared_calculate_capacity = engine_module.calculate_capacity
+
+    def tracked_calculate_capacity(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return shared_calculate_capacity(*args, **kwargs)
+
+    monkeypatch.setattr(engine_module, "calculate_capacity", tracked_calculate_capacity)
+    try:
+        engine.consume(
+            frozen_usage({"requests": 10}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        result = engine.try_consume(
+            frozen_usage({"requests": 5}),
+            current_time=105.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert calls >= 2
+        assert result.available is True
+        assert result.result.pre_capacities[("requests", 10)] == pytest.approx(5.0)
+        assert result.result.post_capacities[("requests", 10)] == pytest.approx(0.0)
+    finally:
+        engine.close()
+
+
+def test_sqlite_marker_refund_and_tombstone_are_one_lifecycle(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path / "marker.sqlite3")
+    reservation_usage = frozen_usage({"requests": 4})
+    bucket_ids = frozenset({("requests", 10)})
+    try:
+        engine.try_consume(
+            reservation_usage,
+            current_time=100.0,
+            reservation_id="reservation-1",
+            reservation_lifetime_seconds=20.0,
+        )
+        marker = engine._connection.execute(
+            "SELECT created_at, expires_at FROM acquire_markers"
+        ).fetchone()
+        assert marker == (100.0, 120.0)
+
+        refunded = engine.refund(
+            reservation_usage,
+            frozen_usage({"requests": 1}),
+            refund_bucket_ids=bucket_ids,
+            current_time=101.0,
+            reservation_id="reservation-1",
+            reservation_model_family="sqlite-tests",
+            reservation_bucket_ids=bucket_ids,
+            reservation_reserved_usage=reservation_usage,
+        )
+        assert refunded.post_capacities[("requests", 10)] == pytest.approx(10.0)
+        assert engine.inspect_counts() == {
+            "buckets": 1,
+            "acquire_markers": 0,
+            "refund_tombstones": 1,
+        }
+        tombstone = engine._connection.execute(
+            "SELECT refunded_at, expires_at FROM refund_tombstones"
+        ).fetchone()
+        assert tombstone == (101.0, 201.0)
+
+        with pytest.raises(DuplicateRefundError) as duplicate:
+            engine.refund(
+                reservation_usage,
+                frozen_usage({"requests": 1}),
+                refund_bucket_ids=bucket_ids,
+                current_time=102.0,
+                reservation_id="reservation-1",
+                reservation_model_family="sqlite-tests",
+                reservation_bucket_ids=bucket_ids,
+                reservation_reserved_usage=reservation_usage,
+            )
+        assert duplicate.value.reason == "already_refunded"
+    finally:
+        engine.close()
+
+
+def test_sqlite_unknown_marker_does_not_credit_capacity(tmp_path: Path) -> None:
+    engine = _engine(tmp_path / "unknown.sqlite3")
+    usage = frozen_usage({"requests": 5})
+    bucket_ids = frozenset({("requests", 10)})
+    try:
+        engine.consume(
+            usage,
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        with pytest.raises(UnknownReservationError):
+            engine.refund(
+                usage,
+                frozen_usage({"requests": 0}),
+                refund_bucket_ids=bucket_ids,
+                current_time=100.0,
+                reservation_id="missing",
+                reservation_model_family="sqlite-tests",
+                reservation_bucket_ids=bucket_ids,
+                reservation_reserved_usage=usage,
+            )
+        remaining = engine.try_consume(
+            usage,
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert remaining.available is True
+        assert remaining.result.post_capacities[("requests", 10)] == 0.0
+    finally:
+        engine.close()
+
+
+def test_sqlite_pruning_is_bounded_per_table(tmp_path: Path) -> None:
+    engine = _engine(
+        tmp_path / "prune.sqlite3",
+        prune_batch_size=1,
+        bucket_ttl_seconds=100,
+        refund_dedup_ttl_seconds=100,
+    )
+    try:
+        for reservation_id in ("expired-1", "expired-2"):
+            engine._connection.execute(
+                "INSERT INTO acquire_markers VALUES (?, ?, ?, '[]', '[]', 1, 2)",
+                ("tests", reservation_id, "sqlite-tests"),
+            )
+            engine._connection.execute(
+                "INSERT INTO refund_tombstones VALUES (?, ?, 1, 2)",
+                ("tests", reservation_id),
+            )
+        engine.consume(
+            frozen_usage({"requests": 0}),
+            current_time=10.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert engine.inspect_counts()["acquire_markers"] == 1
+        assert engine.inspect_counts()["refund_tombstones"] == 1
+    finally:
+        engine.close()
+
+
+def test_sqlite_bucket_ttl_pruning_restores_only_fresh_capacity(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(
+        tmp_path / "bucket-prune.sqlite3",
+        bucket_ttl_seconds=10,
+    )
+    try:
+        engine.consume(
+            frozen_usage({"requests": 10}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        result = engine.consume(
+            frozen_usage({"requests": 1}),
+            current_time=111.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert result.fresh_bucket_ids == (("requests", 10),)
+        assert result.pre_capacities[("requests", 10)] == 10.0
+        assert result.post_capacities[("requests", 10)] == 9.0
+    finally:
+        engine.close()
+
+
+def test_sqlite_negative_refund_preserves_debt_for_linear_refill(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path / "debt.sqlite3")
+    bucket_ids = frozenset({("requests", 10)})
+    try:
+        engine.consume(
+            frozen_usage({"requests": 10}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        refunded = engine.refund(
+            frozen_usage({"requests": 2}),
+            frozen_usage({"requests": 20}),
+            refund_bucket_ids=bucket_ids,
+            current_time=100.0,
+            reservation_id=None,
+            reservation_model_family=None,
+            reservation_bucket_ids=None,
+            reservation_reserved_usage=None,
+        )
+        assert refunded.post_capacities[("requests", 10)] == -10.0
+        halfway = engine.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=105.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert halfway.result.pre_capacities[("requests", 10)] == -5.0
+    finally:
+        engine.close()
+
+
+def test_sqlite_set_max_capacity_anchors_elapsed_time_at_old_rate(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path / "max.sqlite3")
+    try:
+        engine.consume(
+            frozen_usage({"requests": 10}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        engine.set_max_capacity("requests", 10, 20.0, current_time=105.0)
+        anchored = engine.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=105.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert anchored.result.pre_capacities[("requests", 10)] == 5.0
+        refilled = engine.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=110.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert refilled.result.pre_capacities[("requests", 10)] == 15.0
+    finally:
+        engine.close()
+
+
+def test_sqlite_key_prefixes_isolate_capacity_in_one_database(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "prefixes.sqlite3"
+    first = _engine(db_path, key_prefix="first", limit=2.0)
+    second = _engine(db_path, key_prefix="second", limit=2.0)
+    try:
+        first.consume(
+            frozen_usage({"requests": 2}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        second_result = second.try_consume(
+            frozen_usage({"requests": 2}),
+            current_time=100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert second_result.available is True
+    finally:
+        first.close()
+        second.close()
+
+
+def test_sqlite_duplicate_acquire_is_visible_across_connections(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "connections.sqlite3"
+    first = _engine(db_path)
+    second = _engine(db_path)
+    usage = frozen_usage({"requests": 1})
+    try:
+        first.consume(
+            usage,
+            current_time=100.0,
+            reservation_id="shared-reservation",
+            reservation_lifetime_seconds=20.0,
+        )
+        with pytest.raises(DuplicateRefundError) as duplicate:
+            second.consume(
+                usage,
+                current_time=100.0,
+                reservation_id="shared-reservation",
+                reservation_lifetime_seconds=20.0,
+            )
+        assert duplicate.value.reason == "duplicate_acquire"
+    finally:
+        first.close()
+        second.close()
+
+
+def test_sqlite_acquire_marker_can_be_refunded_by_another_process(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "cross-process-refund.sqlite3"
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    process = context.Process(
+        target=_acquire_in_process,
+        args=(str(db_path), "shared", "child-reservation", result_queue),
+    )
+    process.start()
+    process.join(timeout=10)
+    assert process.exitcode == 0
+    assert result_queue.get(timeout=1) == ("acquired", "child-reservation")
+
+    builder = SyncSqliteBackendBuilder(db_path, key_prefix="shared")
+    backend = builder.build(_config(limit=2.0))
+    usage = frozen_usage({"requests": 2})
+    bucket_ids = frozenset({("requests", 10)})
+    try:
+        assert backend.refund_capacity_for_buckets(
+            usage,
+            frozen_usage({"requests": 0}),
+            bucket_ids=bucket_ids,
+            reservation_id="child-reservation",
+            reservation_model_family="sqlite-tests",
+            reservation_bucket_ids=bucket_ids,
+            reservation_reserved_usage=usage,
+        )
+        assert backend.wait_for_capacity(usage, timeout=0) is not None
+    finally:
+        builder.close()
+        result_queue.close()
+
+
+def test_sqlite_cross_process_try_acquire_has_one_atomic_winner(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "cross-process-contention.sqlite3"
+    context = multiprocessing.get_context("spawn")
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_acquire_in_process,
+            args=(str(db_path), "shared", f"reservation-{index}", result_queue),
+        )
+        for index in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=10)
+        assert process.exitcode == 0
+
+    results = [result_queue.get(timeout=1) for _ in processes]
+    assert [status for status, _ in results].count("acquired") == 1
+    assert results.count(("error", "TimeoutError")) == 1
+    with sqlite3.connect(db_path) as connection:
+        marker_count = connection.execute(
+            "SELECT COUNT(*) FROM acquire_markers WHERE key_prefix = 'shared'"
+        ).fetchone()
+    assert marker_count == (1,)
+    result_queue.close()
+
+
+def test_sqlite_builder_resolves_realpath_and_validates_prefix(tmp_path: Path) -> None:
+    unresolved = tmp_path / "nested" / ".." / "state.sqlite3"
+    builder = SyncSqliteBackendBuilder(unresolved, key_prefix="scope")
+    assert builder.db_path == os.path.realpath(unresolved)
+    builder.close()
+
+    with pytest.raises(ValueError, match="key_prefix must not be empty"):
+        SyncSqliteBackendBuilder(tmp_path / "other.sqlite3", key_prefix="")
+
+
+def test_sqlite_ttl_invariants_match_durable_reservation_margin() -> None:
+    derived = derive_default_max_reservation_lifetime_seconds_from_ttls(
+        bucket_ttl_seconds=100,
+        refund_dedup_ttl_seconds=80,
+    )
+    assert derived < 40.0
+    assert math.nextafter(40.0, 0.0) == derived
+
+    with pytest.raises(ValueError, match="SQLite TTLs must exceed"):
+        validate_reservation_lifetime_ttl_invariant(
+            max_reservation_lifetime_seconds=40.0,
+            bucket_ttl_seconds=100,
+            refund_dedup_ttl_seconds=80,
+        )
+
+
+def test_sqlite_builder_rejects_bucket_ttl_shorter_than_quota_window(
+    tmp_path: Path,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        tmp_path / "short-ttl.sqlite3",
+        key_prefix="scope",
+        bucket_ttl_seconds=9,
+        refund_dedup_ttl_seconds=100,
+        max_reservation_lifetime_seconds=4,
+    )
+    try:
+        with pytest.raises(ValueError, match="bucket_ttl_seconds must be >="):
+            builder.build(_config(per_seconds=10))
+    finally:
+        builder.close()
+
+
+def test_sqlite_marker_creation_without_lifetime_rolls_back_consumption(
+    tmp_path: Path,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        tmp_path / "lifetime.sqlite3",
+        key_prefix="scope",
+    )
+    backend = builder.build(_config(limit=2.0))
+    usage = frozen_usage({"requests": 2})
+    try:
+        with pytest.raises(
+            ValueError, match="reservation_lifetime_seconds is required"
+        ):
+            backend.wait_for_capacity(
+                usage,
+                timeout=0,
+                reservation_id="missing-lifetime",
+            )
+        assert backend.wait_for_capacity(usage, timeout=0) is not None
+    finally:
+        builder.close()
+
+
+def test_sqlite_authoritative_refund_requires_all_marker_metadata(
+    tmp_path: Path,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        tmp_path / "metadata.sqlite3",
+        key_prefix="scope",
+    )
+    backend = builder.build(_config(limit=2.0))
+    usage = frozen_usage({"requests": 2})
+    bucket_ids = frozenset({("requests", 10)})
+    try:
+        backend.wait_for_capacity(
+            usage,
+            reservation_id="metadata-reservation",
+            reservation_lifetime_seconds=20.0,
+        )
+        with pytest.raises(ValueError, match="marker metadata is required"):
+            backend.refund_capacity_for_buckets(
+                usage,
+                frozen_usage({"requests": 0}),
+                bucket_ids=bucket_ids,
+                reservation_id="metadata-reservation",
+            )
+        with pytest.raises(TimeoutError):
+            backend.wait_for_capacity(usage, timeout=0)
+    finally:
+        builder.close()

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -604,9 +604,12 @@ def test_sqlite_apply_configured_max_clears_override_and_anchors_state(
 
 def test_sqlite_repairs_far_future_last_checked_on_failed_attempt(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     engine = _engine(tmp_path / "future-clock.sqlite3", bucket_ttl_seconds=10)
     try:
+        monkeypatch.setattr(capacity_module, "_backward_clock_warned", False)
+        monkeypatch.setattr(capacity_module, "_backward_clock_last_warning_at", None)
         engine._connection.execute(
             "UPDATE buckets SET capacity = 0, last_checked = 1000, updated_at = 1000"
         )

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -297,6 +297,90 @@ def test_sqlite_pruning_is_bounded_per_table(tmp_path: Path) -> None:
         engine.close()
 
 
+def test_sqlite_expired_target_marker_is_rejected_beyond_prune_batch(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(
+        tmp_path / "target-marker-expiry.sqlite3",
+        prune_batch_size=1,
+    )
+    usage = frozen_usage({"requests": 4})
+    bucket_ids = frozenset({("requests", 10)})
+    try:
+        engine.consume(
+            usage,
+            current_time=100.0,
+            reservation_id="target-expired-marker",
+            reservation_lifetime_seconds=1.0,
+        )
+        engine._connection.execute(
+            "INSERT INTO acquire_markers VALUES (?, ?, ?, '[]', '[]', 0, 1)",
+            ("tests", "older-expired-marker", "sqlite-tests"),
+        )
+        with pytest.raises(UnknownReservationError):
+            engine.refund(
+                usage,
+                frozen_usage({"requests": 0}),
+                refund_bucket_ids=bucket_ids,
+                current_time=102.0,
+                reservation_id="target-expired-marker",
+                reservation_model_family="sqlite-tests",
+                reservation_bucket_ids=bucket_ids,
+                reservation_reserved_usage=usage,
+            )
+        unavailable = engine.try_consume(
+            frozen_usage({"requests": 9}),
+            current_time=102.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert unavailable.available is False
+    finally:
+        engine.close()
+
+
+def test_sqlite_expired_target_tombstone_allows_id_reuse_beyond_prune_batch(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(
+        tmp_path / "target-tombstone-expiry.sqlite3",
+        refund_dedup_ttl_seconds=2,
+        prune_batch_size=1,
+    )
+    usage = frozen_usage({"requests": 1})
+    bucket_ids = frozenset({("requests", 10)})
+    try:
+        engine.consume(
+            usage,
+            current_time=100.0,
+            reservation_id="reusable-id",
+            reservation_lifetime_seconds=20.0,
+        )
+        engine.refund(
+            usage,
+            usage,
+            refund_bucket_ids=bucket_ids,
+            current_time=100.0,
+            reservation_id="reusable-id",
+            reservation_model_family="sqlite-tests",
+            reservation_bucket_ids=bucket_ids,
+            reservation_reserved_usage=usage,
+        )
+        engine._connection.execute(
+            "INSERT INTO refund_tombstones VALUES (?, ?, 0, 1)",
+            ("tests", "older-expired-tombstone"),
+        )
+        reused = engine.try_consume(
+            frozen_usage({"requests": 0}),
+            current_time=103.0,
+            reservation_id="reusable-id",
+            reservation_lifetime_seconds=20.0,
+        )
+        assert reused.available is True
+    finally:
+        engine.close()
+
+
 def test_sqlite_bucket_ttl_pruning_restores_only_fresh_capacity(
     tmp_path: Path,
 ) -> None:
@@ -529,6 +613,23 @@ def test_sqlite_ttl_invariants_match_durable_reservation_margin() -> None:
             bucket_ttl_seconds=100,
             refund_dedup_ttl_seconds=80,
         )
+
+
+def test_sqlite_builder_lifetime_knob_is_a_fail_fast_upper_bound(
+    tmp_path: Path,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        tmp_path / "builder-lifetime.sqlite3",
+        key_prefix="scope",
+        max_reservation_lifetime_seconds=10.0,
+    )
+    try:
+        assert builder.resolve_max_reservation_lifetime_seconds(None) == 10.0
+        assert builder.resolve_max_reservation_lifetime_seconds(5.0) == 5.0
+        with pytest.raises(ValueError, match="configured maximum"):
+            builder.resolve_max_reservation_lifetime_seconds(11.0)
+    finally:
+        builder.close()
 
 
 def test_sqlite_builder_rejects_bucket_ttl_shorter_than_quota_window(

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -17,6 +17,8 @@ from token_throttle import (
     DuplicateRefundError,
     PerModelConfig,
     Quota,
+    SqliteBackendHealthDiagnostic,
+    SyncRateLimiter,
     SyncSqliteBackendBuilder,
     UnknownReservationError,
     UsageQuotas,
@@ -698,7 +700,7 @@ def test_sync_sqlite_introspection_reports_live_state_and_durable_counts(
         )
         backend.set_max_capacity("requests", 10, 15.0)
         diagnostic = backend.introspect()
-        assert diagnostic.backend_type == "custom"
+        assert diagnostic.backend_type == "sqlite"
         assert len(diagnostic.buckets) == 1
         bucket = diagnostic.buckets[0]
         assert bucket.metric == "requests"
@@ -708,9 +710,54 @@ def test_sync_sqlite_introspection_reports_live_state_and_durable_counts(
         assert bucket.current_capacity is not None
         assert bucket.current_capacity < 10.0
         assert diagnostic.waits == ()
-        assert any("acquire_markers=1" in issue.message for issue in diagnostic.issues)
+        assert diagnostic.sqlite_health == SqliteBackendHealthDiagnostic(
+            model_family_count=1,
+            bucket_count=1,
+            acquire_marker_count=1,
+            refund_tombstone_count=0,
+        )
+        assert diagnostic.issues == ()
     finally:
         builder.close()
+
+
+def test_sync_sqlite_limiter_reports_first_class_health_and_local_estimates(
+    tmp_path: Path,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        tmp_path / "limiter-diagnostics.sqlite3",
+        key_prefix="limiter-diagnostics",
+    )
+    with SyncRateLimiter(_config(), backend=builder) as limiter:
+        reservation = limiter.acquire_capacity(
+            {"requests": 1},
+            model="sqlite-model",
+        )
+
+        assert limiter.snapshot_state() == {
+            "in_flight_reservations": 1,
+            "model_families": 1,
+            "backend_type": "sqlite",
+            "marker_count_estimate": 1,
+            "refund_dedup_count_estimate": 0,
+        }
+        diagnostic = limiter.diagnose()
+        assert diagnostic.backend_type == "sqlite"
+        assert diagnostic.backend_health.sqlite == SqliteBackendHealthDiagnostic(
+            model_family_count=1,
+            bucket_count=1,
+            acquire_marker_count=1,
+            refund_tombstone_count=0,
+        )
+        assert diagnostic.backend_health.custom is None
+
+        limiter.refund_capacity({"requests": 1}, reservation)
+        assert limiter.snapshot_state()["marker_count_estimate"] == 0
+        assert limiter.snapshot_state()["refund_dedup_count_estimate"] == 1
+        refunded_health = limiter.diagnose().backend_health.sqlite
+        assert refunded_health is not None
+        assert refunded_health.acquire_marker_count == 0
+        assert refunded_health.refund_tombstone_count == 1
 
 
 def test_sync_sqlite_introspection_tracks_and_removes_waiters(tmp_path: Path) -> None:

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -39,12 +39,13 @@ from token_throttle._limiter_backends._sqlite._ttl import (
 def _config(
     model_family: str = "sqlite-tests",
     *,
+    metric: str = "requests",
     limit: float = 10.0,
     per_seconds: int = 10,
 ) -> PerModelConfig:
     return PerModelConfig(
         quotas=UsageQuotas(
-            [Quota(metric="requests", limit=limit, per_seconds=per_seconds)]
+            [Quota(metric=metric, limit=limit, per_seconds=per_seconds)]
         ),
         model_family=model_family,
     )
@@ -752,6 +753,29 @@ def test_sync_sqlite_introspection_tracks_and_removes_waiters(tmp_path: Path) ->
         if thread.is_alive():
             backend.refund_capacity(usage, frozen_usage({"requests": 0}))
             thread.join(timeout=1)
+        builder.close()
+
+
+def test_sync_sqlite_metric_rebuilds_close_and_deregister_old_engines(
+    tmp_path: Path,
+) -> None:
+    builder = SyncSqliteBackendBuilder(
+        tmp_path / "sync-rebuild-lifecycle.sqlite3",
+        key_prefix="rebuilds",
+    )
+    current = builder.build(_config(metric="requests"))
+    replaced_engines = []
+    try:
+        for index in range(10):
+            cfg = _config(metric="tokens" if index % 2 == 0 else "requests")
+            replacement = builder.build(cfg)
+            replaced_engines.append(current._engine)
+            current = current.prepare_reconfigured_backend(replacement, cfg)
+            assert len(builder._engines) == 1
+        for engine in replaced_engines:
+            with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+                engine.inspect_counts()
+    finally:
         builder.close()
 
 

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -577,6 +577,30 @@ def test_sqlite_set_max_capacity_anchors_elapsed_time_at_old_rate(
         engine.close()
 
 
+def test_sqlite_set_max_capacity_preserves_uncapped_overflow_across_raise(
+    tmp_path: Path,
+) -> None:
+    engine = _engine(tmp_path / "uncapped-max.sqlite3")
+    try:
+        engine.consume(
+            frozen_usage({"requests": 0}),
+            clock=lambda: 100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        engine.set_max_capacity("requests", 10, 5.0, clock=lambda: 100.0)
+        engine.set_max_capacity("requests", 10, 20.0, clock=lambda: 100.0)
+        raised = engine.try_consume(
+            frozen_usage({"requests": 0}),
+            clock=lambda: 100.0,
+            reservation_id=None,
+            reservation_lifetime_seconds=None,
+        )
+        assert raised.result.pre_capacities[("requests", 10)] == 10.0
+    finally:
+        engine.close()
+
+
 def test_sqlite_configured_limits_remain_process_local(tmp_path: Path) -> None:
     db_path = tmp_path / "local-config.sqlite3"
     first = _engine(db_path, limit=10.0)
@@ -734,6 +758,35 @@ def test_sqlite_repairs_far_future_last_checked_on_failed_attempt(
         )
         assert pruned.result.fresh_bucket_ids == (("requests", 10),)
     finally:
+        engine.close()
+
+
+def test_sqlite_introspection_is_read_only_and_does_not_wait_for_writer(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "read-only-introspection.sqlite3"
+    engine = _engine(db_path)
+    writer = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        engine._connection.execute(
+            "UPDATE buckets SET capacity = NULL, last_checked = 100, "
+            "updated_at = 100, expires_at = 200"
+        )
+        changes_before = engine._connection.total_changes
+        writer.execute("BEGIN IMMEDIATE")
+        started = time.monotonic()
+        snapshots, _ = engine.inspect_snapshot(clock=lambda: 101.0)
+        elapsed = time.monotonic() - started
+        assert elapsed < 0.5
+        assert snapshots[0].current_capacity == 0.0
+        assert engine._connection.total_changes == changes_before
+        assert engine._connection.execute(
+            "SELECT capacity, last_checked FROM buckets"
+        ).fetchone() == (None, 100.0)
+    finally:
+        if writer.in_transaction:
+            writer.execute("ROLLBACK")
+        writer.close()
         engine.close()
 
 
@@ -1042,6 +1095,37 @@ def test_sqlite_builder_resolves_realpath_and_validates_prefix(tmp_path: Path) -
 
     with pytest.raises(ValueError, match="key_prefix must not be empty"):
         SyncSqliteBackendBuilder(tmp_path / "other.sqlite3", key_prefix="")
+
+
+@pytest.mark.parametrize(
+    "db_path", [":memory:", "file:shared?mode=memory&cache=shared"]
+)
+def test_sqlite_builder_rejects_non_filesystem_database_paths(db_path: str) -> None:
+    with pytest.raises(ValueError, match="filesystem path"):
+        SyncSqliteBackendBuilder(db_path, key_prefix="scope")
+
+
+def test_sqlite_missing_parent_error_names_resolved_path(tmp_path: Path) -> None:
+    db_path = tmp_path / "missing" / "state.sqlite3"
+    resolved = os.path.realpath(db_path)
+    builder = SyncSqliteBackendBuilder(db_path, key_prefix="scope")
+    try:
+        with pytest.raises(sqlite3.OperationalError, match=resolved):
+            builder.build(_config())
+    finally:
+        builder.close()
+
+
+def test_sqlite_busy_classification_uses_sqlite_metadata_not_message() -> None:
+    busy = sqlite3.OperationalError("opaque localized message")
+    busy.sqlite_errorcode = sqlite3.SQLITE_BUSY | (2 << 8)
+    busy.sqlite_errorname = "SQLITE_BUSY_SNAPSHOT"
+    assert engine_module._is_busy_error(busy)
+
+    misleading = sqlite3.OperationalError("database is locked")
+    misleading.sqlite_errorcode = sqlite3.SQLITE_ERROR
+    misleading.sqlite_errorname = "SQLITE_ERROR"
+    assert not engine_module._is_busy_error(misleading)
 
 
 def test_sqlite_ttl_invariants_match_durable_reservation_margin() -> None:

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -925,13 +925,13 @@ def test_sync_sqlite_introspection_tracks_and_removes_waiters(tmp_path: Path) ->
     outcome: list[str] = []
 
     def wait() -> None:
-        backend.wait_for_capacity(usage, timeout=2)
+        backend.wait_for_capacity(usage, timeout=10)
         outcome.append("acquired")
 
     thread = threading.Thread(target=wait)
     thread.start()
     try:
-        deadline = time.monotonic() + 1
+        deadline = time.monotonic() + 5
         diagnostic = backend.introspect()
         while not diagnostic.waits and time.monotonic() < deadline:
             time.sleep(0.01)
@@ -940,13 +940,19 @@ def test_sync_sqlite_introspection_tracks_and_removes_waiters(tmp_path: Path) ->
         assert diagnostic.waits[0].state == "waiting_for_capacity"
         assert diagnostic.waits[0].blocked_buckets[0].metric == "requests"
         backend.refund_capacity(usage, frozen_usage({"requests": 0}))
-        thread.join(timeout=1)
+        # The waiter polls on a deficit-driven sleep capped at the 1s
+        # cross-worker interval, so its wake-up after the refund can land a
+        # full second later; give slow CI runners several poll periods.
+        acquired_deadline = time.monotonic() + 5
+        while not outcome and time.monotonic() < acquired_deadline:
+            time.sleep(0.02)
+        thread.join(timeout=5)
         assert outcome == ["acquired"]
         assert backend.introspect().waits == ()
     finally:
         if thread.is_alive():
             backend.refund_capacity(usage, frozen_usage({"requests": 0}))
-            thread.join(timeout=1)
+            thread.join(timeout=5)
         builder.close()
 
 

--- a/tests/unit/test_sqlite_engine.py
+++ b/tests/unit/test_sqlite_engine.py
@@ -1164,8 +1164,10 @@ def test_sqlite_missing_parent_error_names_resolved_path(tmp_path: Path) -> None
     resolved = os.path.realpath(db_path)
     builder = SyncSqliteBackendBuilder(db_path, key_prefix="scope")
     try:
-        # match= is a regex; Windows paths contain backslash escapes like \U.
-        with pytest.raises(sqlite3.OperationalError, match=re.escape(resolved)):
+        # The engine embeds the path with !r, so the message carries repr
+        # quoting (and doubled backslashes on Windows); match that form, and
+        # re.escape it because match= is a regex.
+        with pytest.raises(sqlite3.OperationalError, match=re.escape(repr(resolved))):
             builder.build(_config())
     finally:
         builder.close()

--- a/tests/unit/test_sync_memory_backend.py
+++ b/tests/unit/test_sync_memory_backend.py
@@ -206,8 +206,11 @@ class TestWaitCallbacks:
         backend.consume_capacity(frozendict({"tokens": 100.0}))
         cbs.on_capacity_consumed.reset_mock()
 
-        # rate is 100/sec, so 0.01s sleep should refill ~1 token
-        backend.wait_for_capacity(frozendict({"tokens": 1.0}))
+        # Rate is 100/sec, so 50 tokens need ~0.5s of refill. Requesting a
+        # 10ms refill (1 token) made the test flaky: any scheduling gap of
+        # >=10ms between the drain and the first capacity check meant the
+        # waiter never waited, so on_wait_start legitimately never fired.
+        backend.wait_for_capacity(frozendict({"tokens": 50.0}))
 
         cbs.on_wait_start.assert_called_once()
         call_kwargs = cbs.on_wait_start.call_args.kwargs

--- a/token_throttle/__init__.py
+++ b/token_throttle/__init__.py
@@ -16,6 +16,7 @@ from token_throttle._diagnostic import (
     RedisBackendHealthDiagnostic,
     ReservationGroupDiagnostic,
     RuntimeOverrideDiagnostic,
+    SqliteBackendHealthDiagnostic,
     WaitBucketDiagnostic,
     WaiterDiagnostic,
 )
@@ -271,6 +272,7 @@ __all__ = [
     "SecondsIn",
     "SqliteBackend",
     "SqliteBackendBuilder",
+    "SqliteBackendHealthDiagnostic",
     "SyncBackendIntrospectable",
     "SyncMemoryBackend",
     "SyncMemoryBackendBuilder",

--- a/token_throttle/__init__.py
+++ b/token_throttle/__init__.py
@@ -124,6 +124,10 @@ if TYPE_CHECKING:
         SyncRedisBackendBuilder,
     )
     from token_throttle._limiter_backends._redis._sync_bucket import SyncRedisBucket
+    from token_throttle._limiter_backends._sqlite._backend import (
+        SqliteBackend,
+        SqliteBackendBuilder,
+    )
     from token_throttle._limiter_backends._sqlite._sync_backend import (
         SyncSqliteBackend,
         SyncSqliteBackendBuilder,
@@ -157,6 +161,9 @@ _LAZY_IMPORTS: dict[str, str] = {
     # sync SQLite backend
     "SyncSqliteBackend": "token_throttle._limiter_backends._sqlite._sync_backend",
     "SyncSqliteBackendBuilder": "token_throttle._limiter_backends._sqlite._sync_backend",
+    # async SQLite backend
+    "SqliteBackend": "token_throttle._limiter_backends._sqlite._backend",
+    "SqliteBackendBuilder": "token_throttle._limiter_backends._sqlite._backend",
     # sync redis backend
     "SyncRedisBackend": "token_throttle._limiter_backends._redis._sync_backend",
     "SyncRedisBackendBuilder": "token_throttle._limiter_backends._redis._sync_backend",
@@ -262,6 +269,8 @@ __all__ = [
     "ReservationGroupDiagnostic",
     "RuntimeOverrideDiagnostic",
     "SecondsIn",
+    "SqliteBackend",
+    "SqliteBackendBuilder",
     "SyncBackendIntrospectable",
     "SyncMemoryBackend",
     "SyncMemoryBackendBuilder",

--- a/token_throttle/__init__.py
+++ b/token_throttle/__init__.py
@@ -124,6 +124,10 @@ if TYPE_CHECKING:
         SyncRedisBackendBuilder,
     )
     from token_throttle._limiter_backends._redis._sync_bucket import SyncRedisBucket
+    from token_throttle._limiter_backends._sqlite._sync_backend import (
+        SyncSqliteBackend,
+        SyncSqliteBackendBuilder,
+    )
 
     _STATIC_LAZY_EXPORTS = (
         LOCK_TIMEOUT_SECONDS,
@@ -150,6 +154,9 @@ _LAZY_IMPORTS: dict[str, str] = {
     # sync memory backend
     "SyncMemoryBackend": "token_throttle._limiter_backends._memory._sync_backend",
     "SyncMemoryBackendBuilder": "token_throttle._limiter_backends._memory._sync_backend",
+    # sync SQLite backend
+    "SyncSqliteBackend": "token_throttle._limiter_backends._sqlite._sync_backend",
+    "SyncSqliteBackendBuilder": "token_throttle._limiter_backends._sqlite._sync_backend",
     # sync redis backend
     "SyncRedisBackend": "token_throttle._limiter_backends._redis._sync_backend",
     "SyncRedisBackendBuilder": "token_throttle._limiter_backends._redis._sync_backend",
@@ -268,6 +275,8 @@ __all__ = [
     "SyncRateLimiterBackend",
     "SyncRateLimiterBackendBuilderInterface",
     "SyncRateLimiterCallbacks",
+    "SyncSqliteBackend",
+    "SyncSqliteBackendBuilder",
     "UnknownReservationError",
     "Usage",
     "UsageCounter",

--- a/token_throttle/_capacity.py
+++ b/token_throttle/_capacity.py
@@ -16,6 +16,7 @@ MIN_MAX_CAPACITY = 1e-9
 _logger = logging.getLogger("token_throttle")
 _acquire_logger = logging.getLogger("token_throttle.acquire")
 _MEMORY_BUCKET_ID_PARTS = 4
+_SQLITE_BUCKET_ID_PARTS = 4
 _REDIS_BUCKET_ID_PARTS = 6
 
 
@@ -23,6 +24,8 @@ def _bucket_context_from_bucket_id(bucket_id: str) -> tuple[str, str]:
     """Best-effort extraction for memory and Redis bucket key formats."""
     parts = bucket_id.split(":")
     if len(parts) >= _MEMORY_BUCKET_ID_PARTS and parts[0] == "memory":
+        return parts[1], parts[2]
+    if len(parts) >= _SQLITE_BUCKET_ID_PARTS and parts[0] == "sqlite":
         return parts[1], parts[2]
     if (
         len(parts) >= _REDIS_BUCKET_ID_PARTS

--- a/token_throttle/_diagnostic.py
+++ b/token_throttle/_diagnostic.py
@@ -17,7 +17,7 @@ from token_throttle._interfaces._models import (  # noqa: TC001
     ReservationAuthoritySnapshot,
 )
 
-DiagnosticBackendType = Literal["memory", "redis", "custom", "unknown"]
+DiagnosticBackendType = Literal["memory", "redis", "sqlite", "custom", "unknown"]
 DiagnosticConsistency = Literal["eventually_consistent"]
 DiagnosticIssueSeverity = Literal["info", "warning", "error"]
 DiagnosticBucketStatus = Literal[
@@ -47,7 +47,8 @@ class DiagnosticIssue(StrictDTO):
     component: str = Field(
         description=(
             "Component that produced the issue, for example 'limiter', "
-            "'memory_backend', 'redis_backend', or 'custom_backend'."
+            "'memory_backend', 'redis_backend', 'sqlite_backend', or "
+            "'custom_backend'."
         )
     )
     message: str = Field(
@@ -330,6 +331,19 @@ class RedisBackendHealthDiagnostic(StrictDTO):
     )
 
 
+class SqliteBackendHealthDiagnostic(StrictDTO):
+    model_family_count: int = Field(
+        description="Known model families using SQLite backends."
+    )
+    bucket_count: int = Field(description="Known SQLite buckets for these families.")
+    acquire_marker_count: int = Field(
+        description="Exact acquire-marker row count in this SQLite namespace."
+    )
+    refund_tombstone_count: int = Field(
+        description="Exact refund-tombstone row count in this SQLite namespace."
+    )
+
+
 class CustomBackendHealthDiagnostic(StrictDTO):
     introspection_supported: bool = Field(
         description="Whether the custom backend supplied backend introspection."
@@ -343,6 +357,7 @@ class BackendHealthDiagnostic(StrictDTO):
     backend_type: DiagnosticBackendType = Field(description="Primary backend kind.")
     memory: MemoryBackendHealthDiagnostic | None = Field(default=None)
     redis: RedisBackendHealthDiagnostic | None = Field(default=None)
+    sqlite: SqliteBackendHealthDiagnostic | None = Field(default=None)
     custom: CustomBackendHealthDiagnostic | None = Field(default=None)
 
 
@@ -408,6 +423,7 @@ class BackendIntrospectionDiagnostic(StrictDTO):
     )
     memory_health: MemoryBackendHealthDiagnostic | None = Field(default=None)
     redis_health: RedisBackendHealthDiagnostic | None = Field(default=None)
+    sqlite_health: SqliteBackendHealthDiagnostic | None = Field(default=None)
     issues: tuple[DiagnosticIssue, ...] = Field(default=())
 
 
@@ -932,10 +948,12 @@ def build_backend_health(
 ) -> BackendHealthDiagnostic:
     memory_health = _aggregate_memory_health(backend_results)
     redis_health = _aggregate_redis_health(snapshot, backend_results)
+    sqlite_health = _aggregate_sqlite_health(backend_results)
     custom_health = None
     if unsupported_backend_class_names or snapshot.backend_type not in {
         "memory",
         "redis",
+        "sqlite",
     }:
         custom_health = CustomBackendHealthDiagnostic(
             introspection_supported=not unsupported_backend_class_names,
@@ -950,6 +968,7 @@ def build_backend_health(
         backend_type=snapshot.backend_type,
         memory=memory_health,
         redis=redis_health,
+        sqlite=sqlite_health,
         custom=custom_health,
     )
 
@@ -998,6 +1017,24 @@ def _aggregate_redis_health(
         ),
         local_marker_count_estimate=marker_estimate,
         local_refund_dedup_count_estimate=snapshot.committed_refund_dedup_count,
+    )
+
+
+def _aggregate_sqlite_health(
+    backend_results: list[BackendIntrospectionDiagnostic],
+) -> SqliteBackendHealthDiagnostic | None:
+    healths = [
+        result.sqlite_health for result in backend_results if result.sqlite_health
+    ]
+    if not healths:
+        return None
+    # Each per-family backend reads the same database namespace, so durable row
+    # counts repeat across results rather than partitioning by model family.
+    return SqliteBackendHealthDiagnostic(
+        model_family_count=sum(health.model_family_count for health in healths),
+        bucket_count=sum(health.bucket_count for health in healths),
+        acquire_marker_count=max(health.acquire_marker_count for health in healths),
+        refund_tombstone_count=max(health.refund_tombstone_count for health in healths),
     )
 
 
@@ -1061,7 +1098,7 @@ def build_rate_limiter_diagnostic(
 
 
 def backend_type_from_name(value: object) -> DiagnosticBackendType:
-    if value in {"memory", "redis", "custom", "unknown"}:
+    if value in {"memory", "redis", "sqlite", "custom", "unknown"}:
         return cast("DiagnosticBackendType", value)
     return "unknown"
 
@@ -1072,6 +1109,8 @@ def backend_type_for_object(value: object) -> DiagnosticBackendType:
         return "memory"
     if "._redis." in module:
         return "redis"
+    if "._sqlite." in module:
+        return "sqlite"
     if value is None:
         return "unknown"
     return "custom"

--- a/token_throttle/_exceptions.py
+++ b/token_throttle/_exceptions.py
@@ -95,24 +95,23 @@ class BackendConformanceError(Exception):
 
 class BackendLockContentionError(Exception):
     """
-    Raised when a backend cannot acquire (or loses) its internal per-bucket lock.
+    Raised when a backend cannot acquire or retain required mutation ownership.
 
-    The Redis backend serializes every bucket mutation through a short-lived
-    per-bucket lock. Two situations surface as this exception:
+    Backends use different coordination mechanisms: Redis uses short-lived
+    per-bucket locks, while SQLite uses database write locks. Two broad
+    situations surface as this exception:
 
     * **Acquisition starvation** — the lock could not be acquired within the
-      configured ``lock_blocking_timeout_seconds`` because other workers held
-      it for the whole window. Retry, raise ``lock_blocking_timeout_seconds``,
-      or reduce contention (fewer concurrent callers, smaller bucket fan-out).
+      configured wait because other workers held it for the whole window.
+      Retry, raise the backend's contention timeout, or reduce concurrency.
     * **Mid-operation loss** — the lock expired or was stolen by another worker
       between the read and the write, so the in-progress write was aborted to
       avoid clobbering another worker's state. The operation made no change and
       is safe to retry.
 
-    ``wait_for_capacity`` / ``await_for_capacity`` with no caller timeout absorb
-    this internally and keep waiting, so callers normally see it only from
-    ``consume_capacity``, ``refund_capacity``, ``set_max_capacity``, and
-    reconfiguration. It always chains the underlying cause via ``__cause__``.
+    Waiting capacity operations may absorb this internally and keep polling.
+    Non-waiting mutations surface it after their configured contention window.
+    It always chains the underlying cause via ``__cause__``.
     """
 
     reason = "backend_lock_contention"

--- a/token_throttle/_exceptions.py
+++ b/token_throttle/_exceptions.py
@@ -103,7 +103,9 @@ class BackendLockContentionError(Exception):
 
     * **Acquisition starvation** — the lock could not be acquired within the
       configured wait because other workers held it for the whole window.
-      Retry, raise the backend's contention timeout, or reduce concurrency.
+      Retry, raise the backend's contention timeout
+      (``lock_blocking_timeout_seconds`` for Redis or ``busy_timeout_ms`` for
+      SQLite), or reduce concurrency.
     * **Mid-operation loss** — the lock expired or was stolen by another worker
       between the read and the write, so the in-progress write was aborted to
       avoid clobbering another worker's state. The operation made no change and

--- a/token_throttle/_limiter_backends/_sqlite/__init__.py
+++ b/token_throttle/_limiter_backends/_sqlite/__init__.py
@@ -1,0 +1,1 @@
+"""SQLite-backed rate-limiter storage."""

--- a/token_throttle/_limiter_backends/_sqlite/__init__.py
+++ b/token_throttle/_limiter_backends/_sqlite/__init__.py
@@ -1,1 +1,11 @@
 """SQLite-backed rate-limiter storage."""
+
+from ._backend import SqliteBackend, SqliteBackendBuilder
+from ._sync_backend import SyncSqliteBackend, SyncSqliteBackendBuilder
+
+__all__ = [
+    "SqliteBackend",
+    "SqliteBackendBuilder",
+    "SyncSqliteBackend",
+    "SyncSqliteBackendBuilder",
+]

--- a/token_throttle/_limiter_backends/_sqlite/_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_backend.py
@@ -1,0 +1,941 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import functools
+import logging
+import math
+import random
+import threading
+import time
+import uuid
+import warnings
+from typing import TYPE_CHECKING, ClassVar, TypeVar
+
+from frozendict import frozendict
+
+from token_throttle._capacity import _validate_max_capacity_finite_positive
+from token_throttle._diagnostic import (
+    BackendBucketLimit,
+    BackendIntrospectionDiagnostic,
+    DiagnosticIssue,
+    DiagnosticWaiterState,
+    backend_type_for_object,
+    make_bucket_diagnostic,
+    wait_bucket_diagnostics,
+    waiter_diagnostic_from_state,
+)
+from token_throttle._exceptions import BackendLockContentionError
+from token_throttle._interfaces._callbacks import (
+    BACKEND_CALLBACK_CRITICAL_EXCEPTIONS,
+    RateLimiterCallbacks,
+    current_limiter_callback_context,
+    safe_invoke_async_callback,
+)
+from token_throttle._interfaces._interfaces import (
+    PerModelConfig,
+    RateLimiterBackend,
+    RateLimiterBackendBuilderInterface,
+)
+from token_throttle._validation import (
+    _revalidate_dto,
+    _validate_key_prefix,
+    validate_backend_refund_usage_for_bucket_ids,
+    validate_backend_usage,
+    validate_sleep_interval,
+    validate_timeout,
+)
+
+from ._engine import (
+    DEFAULT_BUSY_TIMEOUT_MS,
+    DEFAULT_PRUNE_BATCH_SIZE,
+    BucketSpec,
+    CapacityResult,
+    SqliteEngine,
+    TryConsumeResult,
+)
+from ._sync_backend import (
+    _log_cancellation_refund_failure,
+    _normalize_usage,
+    _require_marker_metadata,
+    _validate_busy_timeout_ms,
+    _validate_db_path,
+    _validate_marker_refund_scope,
+    _validate_prune_batch_size,
+)
+from ._ttl import (
+    DEFAULT_BUCKET_TTL_SECONDS,
+    DEFAULT_REFUND_DEDUP_TTL_SECONDS,
+    resolve_max_reservation_lifetime_seconds_from_ttls,
+    validate_bucket_ttl_covers_quota_windows,
+    validate_reservation_lifetime_ttl_invariant,
+    validate_sqlite_ttl_seconds,
+)
+
+if TYPE_CHECKING:
+    import os
+    from collections.abc import Callable
+
+    from token_throttle._interfaces._models import BucketId, Capacities, FrozenUsage
+
+_T = TypeVar("_T")
+
+_acquire_logger = logging.getLogger("token_throttle.acquire")
+_refund_logger = logging.getLogger("token_throttle.refund")
+
+
+class SqliteBackendBuilder(RateLimiterBackendBuilderInterface):
+    """Build async SQLite backends with one confined worker thread each."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        db_path: str | os.PathLike[str],
+        *,
+        key_prefix: str,
+        sleep_interval: float | None = None,
+        bucket_ttl_seconds: int = DEFAULT_BUCKET_TTL_SECONDS,
+        refund_dedup_ttl_seconds: int = DEFAULT_REFUND_DEDUP_TTL_SECONDS,
+        override_ttl_seconds: int | None = None,
+        max_reservation_lifetime_seconds: float | None = None,
+        busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+        prune_batch_size: int = DEFAULT_PRUNE_BATCH_SIZE,
+    ) -> None:
+        super().__init__()
+        self._db_path = _validate_db_path(db_path)
+        self._key_prefix = _validate_key_prefix(key_prefix)
+        self._sleep_interval = validate_sleep_interval(sleep_interval)
+        self._bucket_ttl_seconds = validate_sqlite_ttl_seconds(
+            bucket_ttl_seconds, name="bucket_ttl_seconds"
+        )
+        self._refund_dedup_ttl_seconds = validate_sqlite_ttl_seconds(
+            refund_dedup_ttl_seconds, name="refund_dedup_ttl_seconds"
+        )
+        self._override_ttl_seconds = validate_sqlite_ttl_seconds(
+            (
+                self._bucket_ttl_seconds
+                if override_ttl_seconds is None
+                else override_ttl_seconds
+            ),
+            name="override_ttl_seconds",
+        )
+        self._max_reservation_lifetime_seconds = (
+            resolve_max_reservation_lifetime_seconds_from_ttls(
+                max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
+                bucket_ttl_seconds=self._bucket_ttl_seconds,
+                refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+            )
+        )
+        self._busy_timeout_ms = _validate_busy_timeout_ms(busy_timeout_ms)
+        self._prune_batch_size = _validate_prune_batch_size(prune_batch_size)
+        self._backends: list[SqliteBackend] = []
+        self._lock = threading.Lock()
+
+    @property
+    def db_path(self) -> str:
+        return self._db_path
+
+    def resolve_max_reservation_lifetime_seconds(
+        self, max_reservation_lifetime_seconds: float | None
+    ) -> float:
+        if max_reservation_lifetime_seconds is None:
+            return self._max_reservation_lifetime_seconds
+        resolved = resolve_max_reservation_lifetime_seconds_from_ttls(
+            max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
+            bucket_ttl_seconds=self._bucket_ttl_seconds,
+            refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+        )
+        if resolved > self._max_reservation_lifetime_seconds:
+            raise ValueError(
+                "max_reservation_lifetime_seconds exceeds the SQLite builder's "
+                "configured maximum"
+            )
+        return resolved
+
+    def validate_reservation_lifetime_seconds(
+        self, max_reservation_lifetime_seconds: float | None
+    ) -> None:
+        validate_reservation_lifetime_ttl_invariant(
+            max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
+            bucket_ttl_seconds=self._bucket_ttl_seconds,
+            refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+        )
+
+    def build(
+        self,
+        cfg: PerModelConfig,
+        *,
+        callbacks: RateLimiterCallbacks | None = None,
+    ) -> SqliteBackend:
+        cfg = _revalidate_dto(cfg)
+        if callbacks is not None:
+            _revalidate_dto(callbacks)
+        validate_bucket_ttl_covers_quota_windows(
+            bucket_ttl_seconds=self._bucket_ttl_seconds,
+            quotas=cfg.quotas,
+        )
+        executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix="token-throttle-sqlite",
+        )
+
+        def create_engine() -> SqliteEngine:
+            engine = SqliteEngine(
+                db_path=self._db_path,
+                key_prefix=self._key_prefix,
+                model_family=cfg.get_model_family(),
+                buckets=tuple(
+                    BucketSpec(
+                        metric=quota.metric,
+                        per_seconds=int(quota.per_seconds),
+                        configured_max_capacity=float(quota.limit),
+                    )
+                    for quota in cfg.quotas
+                ),
+                bucket_ttl_seconds=self._bucket_ttl_seconds,
+                refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+                override_ttl_seconds=self._override_ttl_seconds,
+                max_reservation_lifetime_seconds=(
+                    self._max_reservation_lifetime_seconds
+                ),
+                busy_timeout_ms=self._busy_timeout_ms,
+                prune_batch_size=self._prune_batch_size,
+            )
+            try:
+                engine.initialize_buckets(time.time())
+            except BaseException:
+                engine.close()
+                raise
+            return engine
+
+        try:
+            engine = executor.submit(create_engine).result()
+        except BaseException:
+            executor.shutdown(wait=True, cancel_futures=True)
+            raise
+        backend = SqliteBackend(
+            engine=engine,
+            executor=executor,
+            callbacks=callbacks,
+            limit_config=cfg,
+            sleep_interval=self._sleep_interval,
+        )
+        with self._lock:
+            self._backends.append(backend)
+        return backend
+
+    async def aclose(self) -> None:
+        with self._lock:
+            backends = tuple(self._backends)
+            self._backends.clear()
+        for backend in backends:
+            await backend.aclose()
+
+    def close(self) -> None:
+        with self._lock:
+            backends = tuple(self._backends)
+            self._backends.clear()
+        for backend in backends:
+            backend.close()
+
+
+class SqliteBackend(RateLimiterBackend):
+    DEFAULT_SLEEP_INTERVAL: ClassVar[float] = 0.1
+    MAX_CROSS_WORKER_POLL: ClassVar[float] = 1.0
+    WAIT_JITTER_RATIO: ClassVar[float] = 0.2
+
+    def __init__(
+        self,
+        *,
+        engine: SqliteEngine,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        limit_config: PerModelConfig,
+        sleep_interval: float | None = None,
+        callbacks: RateLimiterCallbacks | None = None,
+    ) -> None:
+        super().__init__()
+        self._engine = engine
+        self._executor = executor
+        self._limit_config = _revalidate_dto(limit_config)
+        if callbacks is not None:
+            _revalidate_dto(callbacks)
+        self._callbacks = callbacks
+        validated_sleep = validate_sleep_interval(sleep_interval)
+        self._sleep_interval = (
+            self.DEFAULT_SLEEP_INTERVAL if validated_sleep is None else validated_sleep
+        )
+        self._diagnostic_waiters: dict[str, DiagnosticWaiterState] = {}
+        self._close_lock = threading.Lock()
+        self._closed = False
+
+    def supports_metric_set_change(self) -> bool:
+        return True
+
+    def supports_durable_refund_dedup(self) -> bool:
+        return True
+
+    def supports_acquire_marker_authority(self) -> bool:
+        return True
+
+    def _submit(self, callable_: Callable[[], _T]) -> asyncio.Future[_T]:
+        loop = asyncio.get_running_loop()
+        return loop.run_in_executor(self._executor, callable_)
+
+    @staticmethod
+    async def _wait_for_future_while_cancelled(
+        future: asyncio.Future[_T],
+    ) -> bool:
+        while not future.done():
+            try:
+                await asyncio.shield(future)
+            except asyncio.CancelledError:
+                continue
+            except Exception:  # noqa: BLE001
+                break
+        return future.done() and not future.cancelled() and future.exception() is None
+
+    async def _run_engine(self, callable_: Callable[[], _T]) -> _T:
+        future = self._submit(callable_)
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            await self._wait_for_future_while_cancelled(future)
+            raise
+
+    async def _try_consume_cancellation_safe(  # noqa: PLR0913
+        self,
+        usage: FrozenUsage,
+        *,
+        current_time: float,
+        reservation_id: str | None,
+        reservation_lifetime_seconds: float | None,
+        busy_timeout_ms: int,
+        timeout_on_busy: bool,
+    ) -> TryConsumeResult:
+        future = self._submit(
+            functools.partial(
+                self._engine.try_consume,
+                usage,
+                current_time=current_time,
+                reservation_id=reservation_id,
+                reservation_lifetime_seconds=reservation_lifetime_seconds,
+                busy_timeout_ms=busy_timeout_ms,
+                timeout_on_busy=timeout_on_busy,
+            )
+        )
+        try:
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            settled_successfully = await self._wait_for_future_while_cancelled(future)
+            if settled_successfully:
+                attempt = future.result()
+                if attempt.available:
+                    cleanup = self._submit(
+                        functools.partial(
+                            self._engine.cleanup_consumption,
+                            usage,
+                            bucket_ids=self._engine.bucket_ids,
+                            current_time=time.time(),
+                            reservation_id=reservation_id,
+                        )
+                    )
+                    cleanup_ok = await self._wait_for_future_while_cancelled(cleanup)
+                    if not cleanup_ok and cleanup.done() and not cleanup.cancelled():
+                        exc = cleanup.exception()
+                        if exc is not None:
+                            _log_cancellation_refund_failure(
+                                exc,
+                                reservation_id=reservation_id,
+                                usage=usage,
+                            )
+            raise
+
+    async def introspect(self) -> BackendIntrospectionDiagnostic:
+        as_of_monotonic = time.monotonic()
+        snapshots, counts = await self._run_engine(
+            functools.partial(self._engine.inspect_snapshot, current_time=time.time())
+        )
+        buckets = tuple(
+            make_bucket_diagnostic(
+                model_family=self._engine.model_family,
+                metric=snapshot.spec.metric,
+                per_seconds=snapshot.spec.per_seconds,
+                backend_type=backend_type_for_object(self),
+                current_capacity=snapshot.current_capacity,
+                configured_limit=snapshot.spec.configured_max_capacity,
+                effective_max_capacity=snapshot.effective_max_capacity,
+                override_source=("backend" if snapshot.override_active else "none"),
+                status="fresh_start" if snapshot.is_fresh_start else "ok",
+                as_of_monotonic=as_of_monotonic,
+            )
+            for snapshot in snapshots
+        )
+        waiters = tuple(
+            waiter_diagnostic_from_state(state, as_of_monotonic=as_of_monotonic)
+            for state in sorted(
+                self._diagnostic_waiters.values(),
+                key=lambda item: (item.wait_started_monotonic, item.waiter_id),
+            )
+        )
+        issue = DiagnosticIssue(
+            severity="info",
+            component="sqlite_backend",
+            message=(
+                "durable rows: "
+                f"acquire_markers={counts['acquire_markers']}, "
+                f"refund_tombstones={counts['refund_tombstones']}"
+            ),
+            model_family=self._engine.model_family,
+        )
+        return BackendIntrospectionDiagnostic(
+            model_family=self._engine.model_family,
+            backend_type=backend_type_for_object(self),
+            as_of_monotonic=as_of_monotonic,
+            buckets=buckets,
+            waits=waiters,
+            memory_health=None,
+            redis_health=None,
+            issues=(issue,),
+        )
+
+    async def prepare_reconfigured_backend(
+        self,
+        new_backend: RateLimiterBackend,
+        cfg: PerModelConfig,
+    ) -> RateLimiterBackend:
+        if not isinstance(new_backend, SqliteBackend):
+            raise TypeError(
+                "SqliteBackend can only reconfigure into another SqliteBackend"
+            )
+        if (
+            self._engine.db_path != new_backend._engine.db_path  # noqa: SLF001
+            or self._engine.key_prefix != new_backend._engine.key_prefix  # noqa: SLF001
+        ):
+            raise ValueError(
+                "SQLite reconfiguration requires the same db_path and key_prefix"
+            )
+        old_ids = self._engine.bucket_ids
+        new_ids = new_backend._engine.bucket_ids  # noqa: SLF001
+        changed_ids = frozenset(
+            (quota.metric, int(quota.per_seconds))
+            for quota in cfg.quotas
+            if (quota.metric, int(quota.per_seconds)) in old_ids
+            and not math.isclose(
+                self._engine.configured_max_capacity(
+                    quota.metric, int(quota.per_seconds)
+                ),
+                float(quota.limit),
+                rel_tol=1e-12,
+                abs_tol=0.0,
+            )
+        )
+        await self._run_engine(
+            functools.partial(
+                self._engine.clear_max_capacity_overrides,
+                frozenset(old_ids - new_ids) | changed_ids,
+                current_time=time.time(),
+            )
+        )
+        return new_backend
+
+    async def consume_capacity(
+        self,
+        usage: FrozenUsage,
+        *,
+        reservation_id: str | None = None,
+        reservation_lifetime_seconds: float | None = None,
+    ) -> float | None:
+        validate_backend_usage(usage, self._engine.metric_names)
+        usage = _normalize_usage(usage)
+        result = await self._run_engine(
+            functools.partial(
+                self._engine.consume,
+                usage,
+                current_time=time.time(),
+                reservation_id=reservation_id,
+                reservation_lifetime_seconds=reservation_lifetime_seconds,
+            )
+        )
+        self._warn_over_max_consumption(usage, result)
+        await self._emit_consumed_callbacks(usage, result)
+        return result.current_time
+
+    async def await_for_capacity(  # noqa: PLR0915
+        self,
+        usage: FrozenUsage,
+        *,
+        timeout: float | None = None,  # noqa: ASYNC109
+        reservation_id: str | None = None,
+        reservation_lifetime_seconds: float | None = None,
+    ) -> float | None:
+        validate_backend_usage(usage, self._engine.metric_names)
+        timeout = validate_timeout(timeout)
+        usage = _normalize_usage(usage)
+        deadline = None if timeout is None else time.monotonic() + timeout
+        waiter_key = reservation_id or f"sqlite:{uuid.uuid4().hex}"
+        has_waited = False
+        wait_started_at: float | None = None
+        wait_start_callback_overhead = 0.0
+        first_failed_pre: Capacities = frozendict()
+        result: CapacityResult
+        try:
+            while True:
+                busy_timeout_ms, timeout_on_busy = self._wait_busy_timeout(deadline)
+                try:
+                    attempt = await self._try_consume_cancellation_safe(
+                        usage,
+                        current_time=time.time(),
+                        reservation_id=reservation_id,
+                        reservation_lifetime_seconds=reservation_lifetime_seconds,
+                        busy_timeout_ms=busy_timeout_ms,
+                        timeout_on_busy=timeout_on_busy,
+                    )
+                except BackendLockContentionError as exc:
+                    if deadline is not None and time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            "Timed out waiting for SQLite write-lock contention"
+                        ) from exc
+                    sleep_for = self._jittered_sleep(self._sleep_interval)
+                    if deadline is not None:
+                        sleep_for = min(
+                            sleep_for, max(0.0, deadline - time.monotonic())
+                        )
+                    await asyncio.sleep(max(0.001, sleep_for))
+                    continue
+                result = attempt.result
+                if attempt.available:
+                    break
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise self._capacity_timeout_error(
+                        usage, result.pre_capacities, result.max_capacities
+                    )
+                if not has_waited:
+                    has_waited = True
+                    first_failed_pre = result.pre_capacities
+                    wait_started_at = time.monotonic()
+                    if self._callbacks and self._callbacks.on_wait_start:
+                        callback_started = time.monotonic()
+                        if deadline is not None and callback_started >= deadline:
+                            raise self._capacity_timeout_error(
+                                usage, first_failed_pre, result.max_capacities
+                            )
+                        await self._invoke_callback_safe(
+                            self._callbacks.on_wait_start,
+                            callback_slot="on_wait_start",
+                            model_family=self._engine.model_family,
+                            preconsumption_capacities=first_failed_pre,
+                            usage=usage,
+                            **current_limiter_callback_context(),
+                        )
+                        wait_start_callback_overhead += (
+                            time.monotonic() - callback_started
+                        )
+                        if deadline is not None and time.monotonic() >= deadline:
+                            raise self._capacity_timeout_error(
+                                usage, first_failed_pre, result.max_capacities
+                            )
+                self._upsert_diagnostic_waiter(
+                    waiter_key,
+                    reservation_id=reservation_id,
+                    usage=usage,
+                    capacities=result.pre_capacities,
+                    max_capacities=result.max_capacities,
+                    deadline=deadline,
+                    wait_started_at=wait_started_at,
+                )
+                computed = self._compute_sleep(
+                    usage, result.pre_capacities, result.max_capacities
+                )
+                effective = self._jittered_sleep(
+                    min(computed, self.MAX_CROSS_WORKER_POLL)
+                )
+                effective = min(effective, self.MAX_CROSS_WORKER_POLL)
+                if deadline is not None:
+                    effective = min(effective, max(0.0, deadline - time.monotonic()))
+                await asyncio.sleep(max(0.001, effective))
+        finally:
+            self._diagnostic_waiters.pop(waiter_key, None)
+
+        consumed_monotonic = time.monotonic()
+        try:
+            await self._emit_consumed_callbacks(usage, result)
+            if (
+                has_waited
+                and self._callbacks
+                and self._callbacks.after_wait_end_consumption
+            ):
+                wait_time_s = max(
+                    0.0,
+                    consumed_monotonic
+                    - (wait_started_at or consumed_monotonic)
+                    - wait_start_callback_overhead,
+                )
+                await self._invoke_callback_safe(
+                    self._callbacks.after_wait_end_consumption,
+                    callback_slot="after_wait_end_consumption",
+                    model_family=self._engine.model_family,
+                    preconsumption_capacities=result.pre_capacities,
+                    postconsumption_capacities=result.post_capacities,
+                    usage=usage,
+                    wait_time_s=wait_time_s,
+                    **current_limiter_callback_context(),
+                )
+        except BaseException:
+            try:
+                await self._run_engine(
+                    functools.partial(
+                        self._engine.cleanup_consumption,
+                        usage,
+                        bucket_ids=self._engine.bucket_ids,
+                        current_time=time.time(),
+                        reservation_id=reservation_id,
+                    )
+                )
+            except BaseException as refund_exc:  # noqa: BLE001
+                _log_cancellation_refund_failure(
+                    refund_exc,
+                    reservation_id=reservation_id,
+                    usage=usage,
+                )
+            raise
+        return result.current_time
+
+    async def refund_capacity(
+        self,
+        reserved_usage: FrozenUsage,
+        actual_usage: FrozenUsage,
+    ) -> None:
+        await self.refund_capacity_for_buckets(
+            reserved_usage, actual_usage, bucket_ids=self._engine.bucket_ids
+        )
+
+    async def refund_capacity_for_buckets(  # noqa: PLR0913
+        self,
+        reserved_usage: FrozenUsage,
+        actual_usage: FrozenUsage,
+        *,
+        bucket_ids: set[BucketId] | frozenset[BucketId] | None = None,
+        reservation_id: str | None = None,
+        reservation_model_family: str | None = None,
+        reservation_bucket_ids: set[BucketId] | frozenset[BucketId] | None = None,
+        reservation_reserved_usage: FrozenUsage | None = None,
+    ) -> bool:
+        backend_bucket_ids = self._engine.bucket_ids
+        refund_bucket_ids = (
+            backend_bucket_ids if bucket_ids is None else frozenset(bucket_ids)
+        )
+        validate_backend_refund_usage_for_bucket_ids(
+            reserved_usage,
+            actual_usage,
+            refund_bucket_ids,
+            backend_bucket_ids,
+        )
+        reserved_usage = _normalize_usage(reserved_usage)
+        actual_usage = _normalize_usage(actual_usage)
+        marker_model_family: str | None = None
+        marker_bucket_ids: frozenset[BucketId] | None = None
+        marker_reserved_usage: FrozenUsage | None = None
+        if reservation_id is not None:
+            marker_model_family, marker_bucket_ids, marker_reserved_usage = (
+                _require_marker_metadata(
+                    reservation_model_family=reservation_model_family,
+                    reservation_bucket_ids=reservation_bucket_ids,
+                    reservation_reserved_usage=reservation_reserved_usage,
+                )
+            )
+            _validate_marker_refund_scope(
+                reserved_usage=reserved_usage,
+                refund_bucket_ids=refund_bucket_ids,
+                marker_bucket_ids=marker_bucket_ids,
+                marker_reserved_usage=marker_reserved_usage,
+            )
+        if not refund_bucket_ids and reservation_id is None:
+            return True
+        self._warn_refund_overuse(
+            reserved_usage,
+            actual_usage,
+            refund_bucket_ids,
+            reservation_id=reservation_id,
+        )
+        result = await self._run_engine(
+            functools.partial(
+                self._engine.refund,
+                reserved_usage,
+                actual_usage,
+                refund_bucket_ids=refund_bucket_ids,
+                current_time=time.time(),
+                reservation_id=reservation_id,
+                reservation_model_family=marker_model_family,
+                reservation_bucket_ids=marker_bucket_ids,
+                reservation_reserved_usage=marker_reserved_usage,
+            )
+        )
+        await self._fresh_start_buckets_callback(result.fresh_bucket_ids)
+        if self._callbacks and self._callbacks.on_capacity_refunded:
+            await self._invoke_callback_safe(
+                self._callbacks.on_capacity_refunded,
+                callback_slot="on_capacity_refunded",
+                model_family=self._engine.model_family,
+                reserved_usage=reserved_usage,
+                actual_usage=actual_usage,
+                refunded_usage=result.refunded_usage,
+                prerefund_capacities=result.pre_capacities,
+                postrefund_capacities=result.post_capacities,
+            )
+        return True
+
+    async def set_max_capacity(
+        self, metric: str, per_seconds: int, value: float
+    ) -> None:
+        value = _validate_max_capacity_finite_positive(value)
+        await self._run_engine(
+            functools.partial(
+                self._engine.set_max_capacity,
+                metric,
+                per_seconds,
+                value,
+                current_time=time.time(),
+            )
+        )
+
+    async def apply_configured_max_capacity(
+        self, metric: str, per_seconds: int, value: float
+    ) -> None:
+        value = _validate_max_capacity_finite_positive(value)
+        await self._run_engine(
+            functools.partial(
+                self._engine.apply_configured_max_capacity,
+                metric,
+                per_seconds,
+                value,
+                current_time=time.time(),
+            )
+        )
+
+    def _wait_busy_timeout(self, deadline: float | None) -> tuple[int, bool]:
+        if deadline is None:
+            return self._engine.busy_timeout_ms, False
+        remaining = max(0.0, deadline - time.monotonic())
+        timeout_ms = min(
+            self._engine.busy_timeout_ms,
+            max(0, math.ceil(remaining * 1000.0)),
+        )
+        return timeout_ms, timeout_ms == 0
+
+    def _compute_sleep(
+        self,
+        usage: FrozenUsage,
+        capacities: Capacities,
+        max_capacities: Capacities,
+    ) -> float:
+        max_wait = 0.0
+        for (metric, per_seconds), current_capacity in capacities.items():
+            deficit = float(usage.get(metric, 0.0)) - float(current_capacity)
+            if deficit <= 0:
+                continue
+            rate_per_sec = float(max_capacities[(metric, per_seconds)]) / float(
+                per_seconds
+            )
+            if not math.isfinite(rate_per_sec) or rate_per_sec <= 0:
+                raise ValueError(
+                    "Bucket rate is non-positive/non-finite — likely a "
+                    "misconfigured max_capacity"
+                )
+            max_wait = max(max_wait, deficit / rate_per_sec)
+        return max_wait if max_wait > 0 else self._sleep_interval
+
+    def _jittered_sleep(self, value: float) -> float:
+        return value * random.uniform(  # noqa: S311 - scheduling jitter only.
+            1.0 - self.WAIT_JITTER_RATIO,
+            1.0 + self.WAIT_JITTER_RATIO,
+        )
+
+    def _capacity_timeout_error(
+        self,
+        usage: FrozenUsage,
+        capacities: Capacities,
+        max_capacities: Capacities,
+    ) -> TimeoutError:
+        bottleneck_id: BucketId | None = None
+        available: float | None = None
+        requested: float | None = None
+        largest_deficit = 0.0
+        for bucket_id, capacity in capacities.items():
+            metric, _ = bucket_id
+            deficit = float(usage.get(metric, 0.0)) - float(capacity)
+            if deficit > largest_deficit:
+                largest_deficit = deficit
+                bottleneck_id = bucket_id
+                available = float(capacity)
+                requested = float(usage[metric])
+        return TimeoutError(
+            "Timed out waiting for capacity "
+            f"(bottleneck={bottleneck_id}, available={available}, "
+            f"requested={requested}, computed_sleep="
+            f"{self._compute_sleep(usage, capacities, max_capacities)})"
+        )
+
+    def _upsert_diagnostic_waiter(  # noqa: PLR0913
+        self,
+        waiter_key: str,
+        *,
+        reservation_id: str | None,
+        usage: FrozenUsage,
+        capacities: Capacities,
+        max_capacities: Capacities,
+        deadline: float | None,
+        wait_started_at: float | None,
+    ) -> None:
+        limits = {
+            bucket_id: BackendBucketLimit(
+                effective_max_capacity=float(maximum),
+                refill_rate_per_second=float(maximum) / bucket_id[1],
+            )
+            for bucket_id, maximum in max_capacities.items()
+        }
+        self._diagnostic_waiters[waiter_key] = DiagnosticWaiterState(
+            waiter_id=waiter_key,
+            reservation_id=reservation_id,
+            model_family=self._engine.model_family,
+            model=None,
+            request_id=None,
+            state="waiting_for_capacity",
+            usage=usage,
+            wait_started_monotonic=wait_started_at or time.monotonic(),
+            timeout_deadline_monotonic=deadline,
+            blocked_buckets=wait_bucket_diagnostics(
+                model_family=self._engine.model_family,
+                usage=usage,
+                capacities=dict(capacities),
+                limits=limits,
+            ),
+        )
+
+    def _warn_over_max_consumption(
+        self, usage: FrozenUsage, result: CapacityResult
+    ) -> None:
+        for metric, amount in usage.items():
+            for bucket_id, maximum in result.max_capacities.items():
+                if bucket_id[0] != metric or amount <= maximum:
+                    continue
+                message = (
+                    f"record_usage value for {metric} ({amount}) exceeds bucket "
+                    f"max capacity ({maximum}). Capacity will go deeply negative."
+                )
+                warnings.warn(message, RuntimeWarning, stacklevel=3)
+                _acquire_logger.warning(
+                    message,
+                    extra={
+                        "token_throttle_metric": metric,
+                        "token_throttle_model_family": self._engine.model_family,
+                        "token_throttle_value": amount,
+                        "token_throttle_bucket_id": bucket_id,
+                    },
+                )
+
+    def _warn_refund_overuse(
+        self,
+        reserved_usage: FrozenUsage,
+        actual_usage: FrozenUsage,
+        refund_bucket_ids: frozenset[BucketId],
+        *,
+        reservation_id: str | None,
+    ) -> None:
+        for metric, reserved_amount in reserved_usage.items():
+            actual_amount = actual_usage[metric]
+            refund_amount = float(reserved_amount) - float(actual_amount)
+            if refund_amount >= 0:
+                continue
+            message = (
+                f"Actual usage ({actual_amount}) for {metric} exceeds reserved "
+                f"usage ({reserved_amount}). Applying negative refund."
+            )
+            warnings.warn(message, RuntimeWarning, stacklevel=3)
+            _refund_logger.warning(
+                message,
+                extra={
+                    "token_throttle_metric": metric,
+                    "token_throttle_model_family": self._engine.model_family,
+                    "token_throttle_value": refund_amount,
+                    "token_throttle_bucket_ids": sorted(
+                        bucket_id
+                        for bucket_id in refund_bucket_ids
+                        if bucket_id[0] == metric
+                    ),
+                    "token_throttle_reservation_id": reservation_id,
+                },
+            )
+
+    async def _emit_consumed_callbacks(
+        self, usage: FrozenUsage, result: CapacityResult
+    ) -> None:
+        await self._fresh_start_buckets_callback(result.fresh_bucket_ids)
+        if self._callbacks and self._callbacks.on_capacity_consumed:
+            await self._invoke_callback_safe(
+                self._callbacks.on_capacity_consumed,
+                callback_slot="on_capacity_consumed",
+                model_family=self._engine.model_family,
+                preconsumption_capacities=result.pre_capacities,
+                postconsumption_capacities=result.post_capacities,
+                usage=usage,
+                current_time=result.current_time,
+            )
+
+    async def _fresh_start_buckets_callback(
+        self, bucket_ids: tuple[BucketId, ...]
+    ) -> None:
+        if not (
+            bucket_ids
+            and self._callbacks
+            and self._callbacks.on_missing_consumption_data
+        ):
+            return
+        for metric, per_seconds in bucket_ids:
+            await self._invoke_callback_safe(
+                self._callbacks.on_missing_consumption_data,
+                callback_slot="on_missing_consumption_data",
+                model_family=self._engine.model_family,
+                usage_metric=metric,
+                per_seconds=per_seconds,
+            )
+
+    @staticmethod
+    async def _invoke_callback_safe(
+        callback,
+        *,
+        callback_slot: str = "callback",
+        **kwargs,
+    ) -> None:
+        await safe_invoke_async_callback(
+            callback,
+            critical=BACKEND_CALLBACK_CRITICAL_EXCEPTIONS,
+            log_label="Rate limiter callback",
+            callback_slot=callback_slot,
+            **kwargs,
+        )
+
+    def _begin_close(self) -> bool:
+        with self._close_lock:
+            if self._closed:
+                return False
+            self._closed = True
+            return True
+
+    async def aclose(self) -> None:
+        if not self._begin_close():
+            return
+        future = self._submit(self._engine.close)
+        try:
+            await asyncio.shield(future)
+        except asyncio.CancelledError:
+            await self._wait_for_future_while_cancelled(future)
+            raise
+        finally:
+            self._executor.shutdown(wait=True, cancel_futures=True)
+
+    def close(self) -> None:
+        if not self._begin_close():
+            return
+        try:
+            self._executor.submit(self._engine.close).result()
+        finally:
+            self._executor.shutdown(wait=True, cancel_futures=True)

--- a/token_throttle/_limiter_backends/_sqlite/_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_backend.py
@@ -201,7 +201,7 @@ class SqliteBackendBuilder(RateLimiterBackendBuilderInterface):
                 prune_batch_size=self._prune_batch_size,
             )
             try:
-                engine.initialize_buckets(time.time())
+                engine.initialize_buckets()
             except BaseException:
                 engine.close()
                 raise
@@ -309,11 +309,10 @@ class SqliteBackend(RateLimiterBackend):
             await self._wait_for_future_while_cancelled(future)
             raise
 
-    async def _try_consume_cancellation_safe(  # noqa: PLR0913
+    async def _try_consume_cancellation_safe(
         self,
         usage: FrozenUsage,
         *,
-        current_time: float,
         reservation_id: str | None,
         reservation_lifetime_seconds: float | None,
         busy_timeout_ms: int,
@@ -323,7 +322,6 @@ class SqliteBackend(RateLimiterBackend):
             functools.partial(
                 self._engine.try_consume,
                 usage,
-                current_time=current_time,
                 reservation_id=reservation_id,
                 reservation_lifetime_seconds=reservation_lifetime_seconds,
                 busy_timeout_ms=busy_timeout_ms,
@@ -342,7 +340,6 @@ class SqliteBackend(RateLimiterBackend):
                             self._engine.cleanup_consumption,
                             usage,
                             bucket_ids=self._engine.bucket_ids,
-                            current_time=time.time(),
                             reservation_id=reservation_id,
                         )
                     )
@@ -360,9 +357,7 @@ class SqliteBackend(RateLimiterBackend):
 
     async def introspect(self) -> BackendIntrospectionDiagnostic:
         as_of_monotonic = time.monotonic()
-        snapshots, counts = await self._run_engine(
-            functools.partial(self._engine.inspect_snapshot, current_time=time.time())
-        )
+        snapshots, counts = await self._run_engine(self._engine.inspect_snapshot)
         buckets = tuple(
             make_bucket_diagnostic(
                 model_family=self._engine.model_family,
@@ -441,7 +436,6 @@ class SqliteBackend(RateLimiterBackend):
             functools.partial(
                 self._engine.clear_max_capacity_overrides,
                 frozenset(old_ids - new_ids) | changed_ids,
-                current_time=time.time(),
             )
         )
         await self.aclose()
@@ -460,7 +454,6 @@ class SqliteBackend(RateLimiterBackend):
             functools.partial(
                 self._engine.consume,
                 usage,
-                current_time=time.time(),
                 reservation_id=reservation_id,
                 reservation_lifetime_seconds=reservation_lifetime_seconds,
             )
@@ -493,7 +486,6 @@ class SqliteBackend(RateLimiterBackend):
                 try:
                     attempt = await self._try_consume_cancellation_safe(
                         usage,
-                        current_time=time.time(),
                         reservation_id=reservation_id,
                         reservation_lifetime_seconds=reservation_lifetime_seconds,
                         busy_timeout_ms=busy_timeout_ms,
@@ -596,7 +588,6 @@ class SqliteBackend(RateLimiterBackend):
                         self._engine.cleanup_consumption,
                         usage,
                         bucket_ids=self._engine.bucket_ids,
-                        current_time=time.time(),
                         reservation_id=reservation_id,
                     )
                 )
@@ -672,7 +663,6 @@ class SqliteBackend(RateLimiterBackend):
                 reserved_usage,
                 actual_usage,
                 refund_bucket_ids=refund_bucket_ids,
-                current_time=time.time(),
                 reservation_id=reservation_id,
                 reservation_model_family=marker_model_family,
                 reservation_bucket_ids=marker_bucket_ids,
@@ -703,7 +693,6 @@ class SqliteBackend(RateLimiterBackend):
                 metric,
                 per_seconds,
                 value,
-                current_time=time.time(),
             )
         )
 
@@ -717,7 +706,6 @@ class SqliteBackend(RateLimiterBackend):
                 metric,
                 per_seconds,
                 value,
-                current_time=time.time(),
             )
         )
 

--- a/token_throttle/_limiter_backends/_sqlite/_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_backend.py
@@ -287,6 +287,7 @@ class SqliteBackend(RateLimiterBackend):
         while not future.done():
             try:
                 await asyncio.shield(future)
+            # ast-guard: skip — outcome observer; callers own operation cleanup
             except asyncio.CancelledError:
                 continue
             except Exception:  # noqa: BLE001
@@ -297,7 +298,7 @@ class SqliteBackend(RateLimiterBackend):
         future = self._submit(callable_)
         try:
             return await asyncio.shield(future)
-        except asyncio.CancelledError:
+        except BaseException:
             await self._wait_for_future_while_cancelled(future)
             raise
 
@@ -324,7 +325,7 @@ class SqliteBackend(RateLimiterBackend):
         )
         try:
             return await asyncio.shield(future)
-        except asyncio.CancelledError:
+        except BaseException:
             settled_successfully = await self._wait_for_future_while_cancelled(future)
             if settled_successfully:
                 attempt = future.result()
@@ -340,8 +341,9 @@ class SqliteBackend(RateLimiterBackend):
                     )
                     cleanup_ok = await self._wait_for_future_while_cancelled(cleanup)
                     if not cleanup_ok and cleanup.done() and not cleanup.cancelled():
-                        exc = cleanup.exception()
-                        if exc is not None:
+                        try:
+                            cleanup.result()
+                        except BaseException as exc:  # noqa: BLE001
                             _log_cancellation_refund_failure(
                                 exc,
                                 reservation_id=reservation_id,
@@ -926,7 +928,7 @@ class SqliteBackend(RateLimiterBackend):
         future = self._submit(self._engine.close)
         try:
             await asyncio.shield(future)
-        except asyncio.CancelledError:
+        except BaseException:
             await self._wait_for_future_while_cancelled(future)
             raise
         finally:

--- a/token_throttle/_limiter_backends/_sqlite/_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_backend.py
@@ -18,8 +18,8 @@ from token_throttle._capacity import _validate_max_capacity_finite_positive
 from token_throttle._diagnostic import (
     BackendBucketLimit,
     BackendIntrospectionDiagnostic,
-    DiagnosticIssue,
     DiagnosticWaiterState,
+    SqliteBackendHealthDiagnostic,
     backend_type_for_object,
     make_bucket_diagnostic,
     wait_bucket_diagnostics,
@@ -378,16 +378,6 @@ class SqliteBackend(RateLimiterBackend):
                 key=lambda item: (item.wait_started_monotonic, item.waiter_id),
             )
         )
-        issue = DiagnosticIssue(
-            severity="info",
-            component="sqlite_backend",
-            message=(
-                "durable rows: "
-                f"acquire_markers={counts['acquire_markers']}, "
-                f"refund_tombstones={counts['refund_tombstones']}"
-            ),
-            model_family=self._engine.model_family,
-        )
         return BackendIntrospectionDiagnostic(
             model_family=self._engine.model_family,
             backend_type=backend_type_for_object(self),
@@ -396,7 +386,13 @@ class SqliteBackend(RateLimiterBackend):
             waits=waiters,
             memory_health=None,
             redis_health=None,
-            issues=(issue,),
+            sqlite_health=SqliteBackendHealthDiagnostic(
+                model_family_count=1,
+                bucket_count=len(buckets),
+                acquire_marker_count=counts["acquire_markers"],
+                refund_tombstone_count=counts["refund_tombstones"],
+            ),
+            issues=(),
         )
 
     async def prepare_reconfigured_backend(

--- a/token_throttle/_limiter_backends/_sqlite/_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_backend.py
@@ -218,10 +218,15 @@ class SqliteBackendBuilder(RateLimiterBackendBuilderInterface):
             callbacks=callbacks,
             limit_config=cfg,
             sleep_interval=self._sleep_interval,
+            on_close=lambda: self._discard_backend(backend),
         )
         with self._lock:
             self._backends.append(backend)
         return backend
+
+    def _discard_backend(self, backend: SqliteBackend) -> None:
+        with self._lock:
+            self._backends = [item for item in self._backends if item is not backend]
 
     async def aclose(self) -> None:
         with self._lock:
@@ -243,7 +248,7 @@ class SqliteBackend(RateLimiterBackend):
     MAX_CROSS_WORKER_POLL: ClassVar[float] = 1.0
     WAIT_JITTER_RATIO: ClassVar[float] = 0.2
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         engine: SqliteEngine,
@@ -251,6 +256,7 @@ class SqliteBackend(RateLimiterBackend):
         limit_config: PerModelConfig,
         sleep_interval: float | None = None,
         callbacks: RateLimiterCallbacks | None = None,
+        on_close: Callable[[], None] | None = None,
     ) -> None:
         super().__init__()
         self._engine = engine
@@ -266,6 +272,7 @@ class SqliteBackend(RateLimiterBackend):
         self._diagnostic_waiters: dict[str, DiagnosticWaiterState] = {}
         self._close_lock = threading.Lock()
         self._closed = False
+        self._on_close = on_close
 
     def supports_metric_set_change(self) -> bool:
         return True
@@ -437,6 +444,7 @@ class SqliteBackend(RateLimiterBackend):
                 current_time=time.time(),
             )
         )
+        await self.aclose()
         return new_backend
 
     async def consume_capacity(
@@ -933,6 +941,8 @@ class SqliteBackend(RateLimiterBackend):
             raise
         finally:
             self._executor.shutdown(wait=True, cancel_futures=True)
+            if self._on_close is not None:
+                self._on_close()
 
     def close(self) -> None:
         if not self._begin_close():
@@ -941,3 +951,5 @@ class SqliteBackend(RateLimiterBackend):
             self._executor.submit(self._engine.close).result()
         finally:
             self._executor.shutdown(wait=True, cancel_futures=True)
+            if self._on_close is not None:
+                self._on_close()

--- a/token_throttle/_limiter_backends/_sqlite/_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_backend.py
@@ -269,6 +269,8 @@ class SqliteBackend(RateLimiterBackend):
         self._sleep_interval = (
             self.DEFAULT_SLEEP_INTERVAL if validated_sleep is None else validated_sleep
         )
+        # Async backend methods, including introspection, are event-loop confined;
+        # no executor worker reads or mutates this diagnostic-only mapping.
         self._diagnostic_waiters: dict[str, DiagnosticWaiterState] = {}
         self._close_lock = threading.Lock()
         self._closed = False
@@ -474,7 +476,7 @@ class SqliteBackend(RateLimiterBackend):
         timeout = validate_timeout(timeout)
         usage = _normalize_usage(usage)
         deadline = None if timeout is None else time.monotonic() + timeout
-        waiter_key = reservation_id or f"sqlite:{uuid.uuid4().hex}"
+        waiter_key = uuid.uuid4().hex
         has_waited = False
         wait_started_at: float | None = None
         wait_start_callback_overhead = 0.0
@@ -506,6 +508,15 @@ class SqliteBackend(RateLimiterBackend):
                 result = attempt.result
                 if attempt.available:
                     break
+                self._upsert_diagnostic_waiter(
+                    waiter_key,
+                    reservation_id=reservation_id,
+                    usage=usage,
+                    capacities=result.pre_capacities,
+                    max_capacities=result.max_capacities,
+                    deadline=deadline,
+                    wait_started_at=wait_started_at,
+                )
                 if deadline is not None and time.monotonic() >= deadline:
                     raise self._capacity_timeout_error(
                         usage, result.pre_capacities, result.max_capacities
@@ -535,15 +546,6 @@ class SqliteBackend(RateLimiterBackend):
                             raise self._capacity_timeout_error(
                                 usage, first_failed_pre, result.max_capacities
                             )
-                self._upsert_diagnostic_waiter(
-                    waiter_key,
-                    reservation_id=reservation_id,
-                    usage=usage,
-                    capacities=result.pre_capacities,
-                    max_capacities=result.max_capacities,
-                    deadline=deadline,
-                    wait_started_at=wait_started_at,
-                )
                 computed = self._compute_sleep(
                     usage, result.pre_capacities, result.max_capacities
                 )

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -1,0 +1,894 @@
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import math
+import sqlite3
+import threading
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final
+
+from frozendict import frozendict
+
+from token_throttle._capacity import (
+    _calculate_rate_per_sec,
+    _validate_max_capacity_finite_positive,
+    calculate_capacity,
+)
+from token_throttle._exceptions import (
+    BackendLockContentionError,
+    DuplicateRefundError,
+    UnknownReservationError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+    from token_throttle._interfaces._models import BucketId, Capacities, FrozenUsage
+
+SCHEMA_VERSION: Final[int] = 1
+DEFAULT_BUSY_TIMEOUT_MS: Final[int] = 5000
+DEFAULT_PRUNE_BATCH_SIZE: Final[int] = 256
+
+_acquire_logger = logging.getLogger("token_throttle.acquire")
+_refund_logger = logging.getLogger("token_throttle.refund")
+_logger = logging.getLogger("token_throttle")
+
+_SCHEMA_STATEMENTS = (
+    """CREATE TABLE IF NOT EXISTS buckets (
+    key_prefix TEXT NOT NULL,
+    model_family TEXT NOT NULL,
+    metric TEXT NOT NULL,
+    per_seconds INTEGER NOT NULL,
+    capacity REAL,
+    last_checked REAL,
+    max_capacity REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (key_prefix, model_family, metric, per_seconds)
+)""",
+    """CREATE TABLE IF NOT EXISTS acquire_markers (
+    key_prefix TEXT NOT NULL,
+    reservation_id TEXT NOT NULL,
+    model_family TEXT NOT NULL,
+    bucket_ids_json TEXT NOT NULL,
+    reserved_usage_json TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    PRIMARY KEY (key_prefix, reservation_id)
+)""",
+    """CREATE TABLE IF NOT EXISTS refund_tombstones (
+    key_prefix TEXT NOT NULL,
+    reservation_id TEXT NOT NULL,
+    refunded_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    PRIMARY KEY (key_prefix, reservation_id)
+)""",
+    "CREATE INDEX IF NOT EXISTS idx_buckets_updated_at ON buckets(updated_at)",
+    "CREATE INDEX IF NOT EXISTS idx_acquire_markers_expires_at "
+    "ON acquire_markers(expires_at)",
+    "CREATE INDEX IF NOT EXISTS idx_refund_tombstones_expires_at "
+    "ON refund_tombstones(expires_at)",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BucketSpec:
+    metric: str
+    per_seconds: int
+    configured_max_capacity: float
+
+    @property
+    def bucket_id(self) -> BucketId:
+        return (self.metric, self.per_seconds)
+
+
+@dataclass(frozen=True, slots=True)
+class CapacityResult:
+    current_time: float
+    pre_capacities: Capacities
+    post_capacities: Capacities
+    max_capacities: Capacities
+    fresh_bucket_ids: tuple[BucketId, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TryConsumeResult:
+    available: bool
+    result: CapacityResult
+
+
+@dataclass(frozen=True, slots=True)
+class RefundResult:
+    current_time: float
+    pre_capacities: Capacities
+    post_capacities: Capacities
+    refunded_usage: FrozenUsage
+    fresh_bucket_ids: tuple[BucketId, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _BucketState:
+    spec: BucketSpec
+    capacity: float
+    max_capacity: float
+    is_fresh_start: bool
+
+
+def _debug_event(
+    logger: logging.Logger,
+    event_type: str,
+    *,
+    reservation_id: str | None,
+    bucket_id: BucketId | None = None,
+    **fields: object,
+) -> None:
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    event = {
+        "event_type": event_type,
+        "reservation_id": reservation_id,
+        "bucket_id": bucket_id,
+        **fields,
+    }
+    logger.debug(event_type, extra={"token_throttle_event": event})
+
+
+def _bucket_ids_json(bucket_ids: frozenset[BucketId]) -> str:
+    return json.dumps(
+        [[metric, int(per_seconds)] for metric, per_seconds in sorted(bucket_ids)],
+        separators=(",", ":"),
+    )
+
+
+def _usage_json(usage: Mapping[str, float]) -> str:
+    return json.dumps(
+        [[metric, float(amount)] for metric, amount in sorted(usage.items())],
+        separators=(",", ":"),
+    )
+
+
+def _is_busy_error(exc: sqlite3.OperationalError) -> bool:
+    message = str(exc).lower()
+    return "locked" in message or "busy" in message
+
+
+class SqliteEngine:
+    """Backend-agnostic SQLite transaction engine for one model family."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        db_path: str,
+        key_prefix: str,
+        model_family: str,
+        buckets: tuple[BucketSpec, ...],
+        bucket_ttl_seconds: int,
+        refund_dedup_ttl_seconds: int,
+        max_reservation_lifetime_seconds: float,
+        busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+        prune_batch_size: int = DEFAULT_PRUNE_BATCH_SIZE,
+    ) -> None:
+        self.db_path = db_path
+        self.key_prefix = key_prefix
+        self.model_family = model_family
+        self._buckets = buckets
+        self._bucket_by_id = {bucket.bucket_id: bucket for bucket in buckets}
+        self._bucket_ttl_seconds = bucket_ttl_seconds
+        self._refund_dedup_ttl_seconds = refund_dedup_ttl_seconds
+        self._max_reservation_lifetime_seconds = max_reservation_lifetime_seconds
+        self._prune_batch_size = prune_batch_size
+        self._lock = threading.RLock()
+        try:
+            self._connection = sqlite3.connect(
+                db_path,
+                timeout=busy_timeout_ms / 1000.0,
+                isolation_level=None,
+                check_same_thread=False,
+            )
+            self._connection.execute(f"PRAGMA busy_timeout={busy_timeout_ms:d}")
+            self._connection.execute("PRAGMA journal_mode=WAL")
+            self._connection.execute("PRAGMA synchronous=NORMAL")
+            self._initialize_schema()
+        except BaseException:
+            connection = getattr(self, "_connection", None)
+            if connection is not None:
+                connection.close()
+            raise
+
+    @property
+    def bucket_ids(self) -> frozenset[BucketId]:
+        return frozenset(self._bucket_by_id)
+
+    @property
+    def metric_names(self) -> set[str]:
+        return {bucket.metric for bucket in self._buckets}
+
+    def close(self) -> None:
+        with self._lock:
+            self._connection.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            try:
+                self._connection.execute("BEGIN IMMEDIATE")
+                yield self._connection
+                self._connection.execute("COMMIT")
+            except BaseException as exc:
+                with contextlib.suppress(sqlite3.Error):
+                    self._connection.execute("ROLLBACK")
+                if isinstance(exc, sqlite3.OperationalError) and _is_busy_error(exc):
+                    raise BackendLockContentionError(
+                        "SQLite database remained busy or locked beyond "
+                        "busy_timeout; the transaction made no change and is safe "
+                        "to retry."
+                    ) from exc
+                raise
+
+    def _initialize_schema(self) -> None:
+        with self._transaction() as connection:
+            connection.execute(
+                "CREATE TABLE IF NOT EXISTS meta "
+                "(key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+            )
+            row = connection.execute(
+                "SELECT value FROM meta WHERE key = 'schema_version'"
+            ).fetchone()
+            if row is None:
+                connection.execute(
+                    "INSERT INTO meta(key, value) VALUES ('schema_version', ?)",
+                    (str(SCHEMA_VERSION),),
+                )
+            elif row[0] != str(SCHEMA_VERSION):
+                raise RuntimeError(
+                    "Unsupported token-throttle SQLite schema version "
+                    f"{row[0]!r}; this package supports version {SCHEMA_VERSION}. "
+                    "Use a compatible token-throttle version or a different database."
+                )
+            for statement in _SCHEMA_STATEMENTS:
+                connection.execute(statement)
+
+    def initialize_buckets(self, current_time: float) -> None:
+        with self._transaction() as connection:
+            self._prune(connection, current_time)
+            for bucket in self._buckets:
+                max_capacity = _validate_max_capacity_finite_positive(
+                    bucket.configured_max_capacity
+                )
+                connection.execute(
+                    "INSERT OR IGNORE INTO buckets "
+                    "(key_prefix, model_family, metric, per_seconds, capacity, "
+                    "last_checked, max_capacity, updated_at) "
+                    "VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
+                    (
+                        self.key_prefix,
+                        self.model_family,
+                        bucket.metric,
+                        bucket.per_seconds,
+                        max_capacity,
+                        current_time,
+                    ),
+                )
+
+    def _prune(self, connection: sqlite3.Connection, current_time: float) -> None:
+        connection.execute(
+            "DELETE FROM acquire_markers WHERE rowid IN "
+            "(SELECT rowid FROM acquire_markers WHERE expires_at <= ? LIMIT ?)",
+            (current_time, self._prune_batch_size),
+        )
+        connection.execute(
+            "DELETE FROM refund_tombstones WHERE rowid IN "
+            "(SELECT rowid FROM refund_tombstones WHERE expires_at <= ? LIMIT ?)",
+            (current_time, self._prune_batch_size),
+        )
+        connection.execute(
+            "DELETE FROM buckets WHERE rowid IN "
+            "(SELECT rowid FROM buckets WHERE updated_at <= ? LIMIT ?)",
+            (current_time - self._bucket_ttl_seconds, self._prune_batch_size),
+        )
+
+    def _bucket_log_id(self, bucket: BucketSpec) -> str:
+        return f"sqlite:{self.model_family}:{bucket.metric}:{bucket.per_seconds}"
+
+    def _load_states(
+        self,
+        connection: sqlite3.Connection,
+        current_time: float,
+    ) -> tuple[dict[BucketId, _BucketState], tuple[BucketId, ...]]:
+        states: dict[BucketId, _BucketState] = {}
+        fresh: list[BucketId] = []
+        for spec in self._buckets:
+            row = connection.execute(
+                "SELECT capacity, last_checked, max_capacity FROM buckets "
+                "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
+                "AND per_seconds = ?",
+                (
+                    self.key_prefix,
+                    self.model_family,
+                    spec.metric,
+                    spec.per_seconds,
+                ),
+            ).fetchone()
+            if row is None:
+                max_capacity = _validate_max_capacity_finite_positive(
+                    spec.configured_max_capacity
+                )
+                connection.execute(
+                    "INSERT INTO buckets "
+                    "(key_prefix, model_family, metric, per_seconds, capacity, "
+                    "last_checked, max_capacity, updated_at) "
+                    "VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
+                    (
+                        self.key_prefix,
+                        self.model_family,
+                        spec.metric,
+                        spec.per_seconds,
+                        max_capacity,
+                        current_time,
+                    ),
+                )
+                capacity_value: float | None = None
+                last_checked_value: float | None = None
+            else:
+                capacity_value = row[0]
+                last_checked_value = row[1]
+                max_capacity = _validate_max_capacity_finite_positive(row[2])
+
+            if (capacity_value is None) != (last_checked_value is None):
+                _logger.warning(
+                    "Partial SQLite bucket state detected; draining fail-closed; "
+                    "metric=%s model_family=%s bucket_id=%s",
+                    spec.metric,
+                    self.model_family,
+                    self._bucket_log_id(spec),
+                )
+                capacity_value = 0.0
+                last_checked_value = current_time
+                connection.execute(
+                    "UPDATE buckets SET capacity = 0.0, last_checked = ?, "
+                    "updated_at = ? WHERE key_prefix = ? AND model_family = ? "
+                    "AND metric = ? AND per_seconds = ?",
+                    (
+                        current_time,
+                        current_time,
+                        self.key_prefix,
+                        self.model_family,
+                        spec.metric,
+                        spec.per_seconds,
+                    ),
+                )
+
+            calculated = calculate_capacity(
+                last_checked=last_checked_value,
+                outdated_capacity=capacity_value,
+                current_time=current_time,
+                max_capacity=max_capacity,
+                rate_per_sec=_calculate_rate_per_sec(
+                    max_capacity,
+                    spec.per_seconds,
+                ),
+                bucket_id=self._bucket_log_id(spec),
+            )
+            if calculated.is_fresh_start:
+                fresh.append(spec.bucket_id)
+            states[spec.bucket_id] = _BucketState(
+                spec=spec,
+                capacity=calculated.amount,
+                max_capacity=max_capacity,
+                is_fresh_start=calculated.is_fresh_start,
+            )
+        return states, tuple(fresh)
+
+    @staticmethod
+    def _capacities(states: Mapping[BucketId, _BucketState]) -> Capacities:
+        return frozendict(
+            {bucket_id: state.capacity for bucket_id, state in states.items()}
+        )
+
+    def _write_capacities(
+        self,
+        connection: sqlite3.Connection,
+        capacities: Mapping[BucketId, float],
+        current_time: float,
+    ) -> None:
+        for (metric, per_seconds), amount in capacities.items():
+            if not math.isfinite(float(amount)):
+                raise ValueError(f"capacity must be finite (got {amount!r})")
+            normalized = 0.0 if float(amount) == 0.0 else float(amount)
+            cursor = connection.execute(
+                "UPDATE buckets SET capacity = ?, last_checked = ?, updated_at = ? "
+                "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
+                "AND per_seconds = ?",
+                (
+                    normalized,
+                    current_time,
+                    current_time,
+                    self.key_prefix,
+                    self.model_family,
+                    metric,
+                    per_seconds,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError(
+                    f"SQLite bucket '{metric}/{per_seconds}s' disappeared during "
+                    "a write transaction"
+                )
+
+    def _raise_if_duplicate_acquire(
+        self,
+        connection: sqlite3.Connection,
+        reservation_id: str | None,
+    ) -> None:
+        if reservation_id is None:
+            return
+        marker = connection.execute(
+            "SELECT 1 FROM acquire_markers WHERE key_prefix = ? AND reservation_id = ?",
+            (self.key_prefix, reservation_id),
+        ).fetchone()
+        tombstone = connection.execute(
+            "SELECT 1 FROM refund_tombstones WHERE key_prefix = ? "
+            "AND reservation_id = ?",
+            (self.key_prefix, reservation_id),
+        ).fetchone()
+        _debug_event(
+            _acquire_logger,
+            "sqlite_acquire_marker_read",
+            reservation_id=reservation_id,
+            found=marker is not None,
+        )
+        if marker is not None or tombstone is not None:
+            raise DuplicateRefundError(
+                "reservation already acquired",
+                reason="duplicate_acquire",
+                reservation_id=reservation_id,
+                model_family=self.model_family,
+            )
+
+    def _insert_marker(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        reservation_id: str | None,
+        usage: FrozenUsage,
+        reservation_lifetime_seconds: float | None,
+        current_time: float,
+    ) -> None:
+        if reservation_id is None:
+            return
+        if reservation_lifetime_seconds is None:
+            raise ValueError(
+                "reservation_lifetime_seconds is required when reservation_id "
+                "is supplied"
+            )
+        lifetime = float(reservation_lifetime_seconds)
+        if not math.isfinite(lifetime) or lifetime <= 0:
+            raise ValueError(
+                "reservation_lifetime_seconds must be finite and greater than 0"
+            )
+        if lifetime > self._max_reservation_lifetime_seconds:
+            raise ValueError(
+                "reservation_lifetime_seconds exceeds the SQLite backend's "
+                "max_reservation_lifetime_seconds"
+            )
+        _debug_event(
+            _acquire_logger,
+            "sqlite_acquire_marker_write",
+            reservation_id=reservation_id,
+        )
+        connection.execute(
+            "INSERT INTO acquire_markers "
+            "(key_prefix, reservation_id, model_family, bucket_ids_json, "
+            "reserved_usage_json, created_at, expires_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                self.key_prefix,
+                reservation_id,
+                self.model_family,
+                _bucket_ids_json(self.bucket_ids),
+                _usage_json(usage),
+                current_time,
+                current_time + lifetime,
+            ),
+        )
+
+    def try_consume(
+        self,
+        usage: FrozenUsage,
+        *,
+        current_time: float,
+        reservation_id: str | None,
+        reservation_lifetime_seconds: float | None,
+    ) -> TryConsumeResult:
+        with self._transaction() as connection:
+            self._prune(connection, current_time)
+            self._raise_if_duplicate_acquire(connection, reservation_id)
+            states, fresh = self._load_states(connection, current_time)
+            pre = self._capacities(states)
+            max_capacities = frozendict(
+                {bucket_id: state.max_capacity for bucket_id, state in states.items()}
+            )
+            for metric, amount in usage.items():
+                for state in states.values():
+                    if state.spec.metric == metric and amount > state.max_capacity:
+                        raise ValueError(
+                            f"Usage value for {metric} ({amount}) exceeds bucket max "
+                            f"capacity ({state.max_capacity}) for the "
+                            f"{state.spec.per_seconds}s window"
+                        )
+            available = all(
+                float(usage.get(metric, 0.0)) <= state.capacity
+                for (metric, _), state in states.items()
+            )
+            if not available:
+                return TryConsumeResult(
+                    available=False,
+                    result=CapacityResult(
+                        current_time=current_time,
+                        pre_capacities=pre,
+                        post_capacities=frozendict(),
+                        max_capacities=max_capacities,
+                        fresh_bucket_ids=fresh,
+                    ),
+                )
+            post = frozendict(
+                {
+                    bucket_id: state.capacity - float(usage.get(state.spec.metric, 0.0))
+                    for bucket_id, state in states.items()
+                }
+            )
+            self._write_capacities(connection, post, current_time)
+            self._insert_marker(
+                connection,
+                reservation_id=reservation_id,
+                usage=usage,
+                reservation_lifetime_seconds=reservation_lifetime_seconds,
+                current_time=current_time,
+            )
+            return TryConsumeResult(
+                available=True,
+                result=CapacityResult(
+                    current_time=current_time,
+                    pre_capacities=pre,
+                    post_capacities=post,
+                    max_capacities=max_capacities,
+                    fresh_bucket_ids=fresh,
+                ),
+            )
+
+    def consume(
+        self,
+        usage: FrozenUsage,
+        *,
+        current_time: float,
+        reservation_id: str | None,
+        reservation_lifetime_seconds: float | None,
+    ) -> CapacityResult:
+        with self._transaction() as connection:
+            self._prune(connection, current_time)
+            self._raise_if_duplicate_acquire(connection, reservation_id)
+            states, fresh = self._load_states(connection, current_time)
+            pre = self._capacities(states)
+            max_capacities = frozendict(
+                {bucket_id: state.max_capacity for bucket_id, state in states.items()}
+            )
+            post = frozendict(
+                {
+                    bucket_id: max(
+                        -state.max_capacity,
+                        state.capacity - float(usage.get(state.spec.metric, 0.0)),
+                    )
+                    for bucket_id, state in states.items()
+                }
+            )
+            self._write_capacities(connection, post, current_time)
+            self._insert_marker(
+                connection,
+                reservation_id=reservation_id,
+                usage=usage,
+                reservation_lifetime_seconds=reservation_lifetime_seconds,
+                current_time=current_time,
+            )
+            return CapacityResult(
+                current_time=current_time,
+                pre_capacities=pre,
+                post_capacities=post,
+                max_capacities=max_capacities,
+                fresh_bucket_ids=fresh,
+            )
+
+    def _verify_marker(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        reservation_id: str,
+        reservation_model_family: str,
+        reservation_bucket_ids: frozenset[BucketId],
+        reservation_reserved_usage: FrozenUsage,
+    ) -> None:
+        tombstone = connection.execute(
+            "SELECT 1 FROM refund_tombstones WHERE key_prefix = ? "
+            "AND reservation_id = ?",
+            (self.key_prefix, reservation_id),
+        ).fetchone()
+        if tombstone is not None:
+            raise DuplicateRefundError(
+                "reservation already refunded",
+                reason="already_refunded",
+                reservation_id=reservation_id,
+                model_family=reservation_model_family,
+            )
+        marker = connection.execute(
+            "SELECT model_family, bucket_ids_json, reserved_usage_json "
+            "FROM acquire_markers WHERE key_prefix = ? AND reservation_id = ?",
+            (self.key_prefix, reservation_id),
+        ).fetchone()
+        _debug_event(
+            _refund_logger,
+            "sqlite_refund_marker_read",
+            reservation_id=reservation_id,
+            found=marker is not None,
+        )
+        if marker is None:
+            raise UnknownReservationError(
+                reservation_id=reservation_id,
+                model_family=reservation_model_family,
+            )
+        if (
+            marker[0] != reservation_model_family
+            or marker[1] != _bucket_ids_json(reservation_bucket_ids)
+            or marker[2] != _usage_json(reservation_reserved_usage)
+        ):
+            raise UnknownReservationError(
+                reservation_id=reservation_id,
+                model_family=reservation_model_family,
+            )
+
+    def refund(  # noqa: PLR0913
+        self,
+        reserved_usage: FrozenUsage,
+        actual_usage: FrozenUsage,
+        *,
+        refund_bucket_ids: frozenset[BucketId],
+        current_time: float,
+        reservation_id: str | None,
+        reservation_model_family: str | None,
+        reservation_bucket_ids: frozenset[BucketId] | None,
+        reservation_reserved_usage: FrozenUsage | None,
+    ) -> RefundResult:
+        refund_usage = frozendict(
+            {
+                metric: float(amount) - float(actual_usage[metric])
+                for metric, amount in reserved_usage.items()
+            }
+        )
+        with self._transaction() as connection:
+            self._prune(connection, current_time)
+            if reservation_id is not None:
+                if (
+                    reservation_model_family is None
+                    or reservation_bucket_ids is None
+                    or reservation_reserved_usage is None
+                ):
+                    raise ValueError(
+                        "reservation marker metadata is required for "
+                        "marker-authorized refunds"
+                    )
+                self._verify_marker(
+                    connection,
+                    reservation_id=reservation_id,
+                    reservation_model_family=reservation_model_family,
+                    reservation_bucket_ids=reservation_bucket_ids,
+                    reservation_reserved_usage=reservation_reserved_usage,
+                )
+            states, fresh = self._load_states(connection, current_time)
+            pre = self._capacities(states)
+            post_dict = dict(pre)
+            for bucket_id in refund_bucket_ids:
+                state = states[bucket_id]
+                refund_amount = max(
+                    float(refund_usage[state.spec.metric]),
+                    -state.max_capacity,
+                )
+                post_dict[bucket_id] = max(
+                    -state.max_capacity,
+                    min(state.capacity + refund_amount, state.max_capacity),
+                )
+            post = frozendict(post_dict)
+            self._write_capacities(
+                connection,
+                {bucket_id: post[bucket_id] for bucket_id in refund_bucket_ids},
+                current_time,
+            )
+            if reservation_id is not None:
+                deleted = connection.execute(
+                    "DELETE FROM acquire_markers WHERE key_prefix = ? "
+                    "AND reservation_id = ?",
+                    (self.key_prefix, reservation_id),
+                )
+                if deleted.rowcount != 1:
+                    raise RuntimeError(
+                        "SQLite acquire marker disappeared during refund transaction"
+                    )
+                _debug_event(
+                    _refund_logger,
+                    "sqlite_refund_marker_delete",
+                    reservation_id=reservation_id,
+                )
+                connection.execute(
+                    "INSERT INTO refund_tombstones "
+                    "(key_prefix, reservation_id, refunded_at, expires_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        self.key_prefix,
+                        reservation_id,
+                        current_time,
+                        current_time + self._refund_dedup_ttl_seconds,
+                    ),
+                )
+                _debug_event(
+                    _refund_logger,
+                    "sqlite_refund_dedup_write",
+                    reservation_id=reservation_id,
+                )
+            return RefundResult(
+                current_time=current_time,
+                pre_capacities=pre,
+                post_capacities=post,
+                refunded_usage=refund_usage,
+                fresh_bucket_ids=fresh,
+            )
+
+    def cleanup_consumption(
+        self,
+        usage: FrozenUsage,
+        *,
+        bucket_ids: frozenset[BucketId],
+        current_time: float,
+        reservation_id: str | None,
+    ) -> None:
+        with self._transaction() as connection:
+            self._prune(connection, current_time)
+            if reservation_id is not None:
+                marker = connection.execute(
+                    "SELECT 1 FROM acquire_markers WHERE key_prefix = ? "
+                    "AND reservation_id = ?",
+                    (self.key_prefix, reservation_id),
+                ).fetchone()
+                if marker is None:
+                    raise UnknownReservationError(
+                        reservation_id=reservation_id,
+                        model_family=self.model_family,
+                    )
+            states, _ = self._load_states(connection, current_time)
+            refunded = {
+                bucket_id: min(
+                    states[bucket_id].capacity
+                    + float(usage.get(states[bucket_id].spec.metric, 0.0)),
+                    states[bucket_id].max_capacity,
+                )
+                for bucket_id in bucket_ids
+                if bucket_id in states
+            }
+            self._write_capacities(connection, refunded, current_time)
+            if reservation_id is not None:
+                connection.execute(
+                    "DELETE FROM acquire_markers WHERE key_prefix = ? "
+                    "AND reservation_id = ?",
+                    (self.key_prefix, reservation_id),
+                )
+                _debug_event(
+                    _acquire_logger,
+                    "sqlite_acquire_marker_delete",
+                    reservation_id=reservation_id,
+                )
+
+    def set_max_capacity(
+        self,
+        metric: str,
+        per_seconds: int,
+        value: float,
+        *,
+        current_time: float,
+    ) -> None:
+        value = _validate_max_capacity_finite_positive(value)
+        bucket_id = (metric, per_seconds)
+        if bucket_id not in self._bucket_by_id:
+            raise ValueError(f"Bucket '{metric}/{per_seconds}s' not found")
+        spec = self._bucket_by_id[bucket_id]
+        with self._transaction() as connection:
+            self._prune(connection, current_time)
+            row = connection.execute(
+                "SELECT capacity, last_checked, max_capacity FROM buckets "
+                "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
+                "AND per_seconds = ?",
+                (
+                    self.key_prefix,
+                    self.model_family,
+                    metric,
+                    per_seconds,
+                ),
+            ).fetchone()
+            if row is None:
+                connection.execute(
+                    "INSERT INTO buckets "
+                    "(key_prefix, model_family, metric, per_seconds, capacity, "
+                    "last_checked, max_capacity, updated_at) "
+                    "VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
+                    (
+                        self.key_prefix,
+                        self.model_family,
+                        metric,
+                        per_seconds,
+                        value,
+                        current_time,
+                    ),
+                )
+                return
+            capacity, last_checked, old_max = row
+            old_max = _validate_max_capacity_finite_positive(old_max)
+            if (capacity is None) != (last_checked is None):
+                capacity = 0.0
+                last_checked = current_time
+            if capacity is not None and last_checked is not None:
+                calculate_capacity(
+                    last_checked=last_checked,
+                    outdated_capacity=capacity,
+                    current_time=current_time,
+                    max_capacity=old_max,
+                    rate_per_sec=_calculate_rate_per_sec(
+                        old_max,
+                        spec.per_seconds,
+                    ),
+                    bucket_id=self._bucket_log_id(spec),
+                )
+                elapsed = max(0.0, current_time - float(last_checked))
+                anchored = float(capacity) + elapsed * _calculate_rate_per_sec(
+                    old_max,
+                    spec.per_seconds,
+                )
+                if not math.isfinite(anchored):
+                    anchored = old_max
+                capacity = anchored
+                last_checked = current_time
+            connection.execute(
+                "UPDATE buckets SET capacity = ?, last_checked = ?, "
+                "max_capacity = ?, updated_at = ? WHERE key_prefix = ? "
+                "AND model_family = ? AND metric = ? AND per_seconds = ?",
+                (
+                    capacity,
+                    last_checked,
+                    value,
+                    current_time,
+                    self.key_prefix,
+                    self.model_family,
+                    metric,
+                    per_seconds,
+                ),
+            )
+
+    def inspect_counts(self) -> dict[str, int]:
+        """Return scoped row counts for deterministic backend-specific tests."""
+        with self._lock:
+            return {
+                "buckets": int(
+                    self._connection.execute(
+                        "SELECT COUNT(*) FROM buckets WHERE key_prefix = ?",
+                        (self.key_prefix,),
+                    ).fetchone()[0]
+                ),
+                "acquire_markers": int(
+                    self._connection.execute(
+                        "SELECT COUNT(*) FROM acquire_markers WHERE key_prefix = ?",
+                        (self.key_prefix,),
+                    ).fetchone()[0]
+                ),
+                "refund_tombstones": int(
+                    self._connection.execute(
+                        "SELECT COUNT(*) FROM refund_tombstones WHERE key_prefix = ?",
+                        (self.key_prefix,),
+                    ).fetchone()[0]
+                ),
+            }

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -6,6 +6,7 @@ import logging
 import math
 import sqlite3
 import threading
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final
@@ -187,9 +188,7 @@ class SqliteEngine:
                 isolation_level=None,
                 check_same_thread=False,
             )
-            self._connection.execute(f"PRAGMA busy_timeout={busy_timeout_ms:d}")
-            self._connection.execute("PRAGMA journal_mode=WAL")
-            self._connection.execute("PRAGMA synchronous=NORMAL")
+            self._configure_connection(busy_timeout_ms)
             self._initialize_schema()
         except BaseException:
             connection = getattr(self, "_connection", None)
@@ -208,6 +207,33 @@ class SqliteEngine:
     def close(self) -> None:
         with self._lock:
             self._connection.close()
+
+    def _configure_connection(self, busy_timeout_ms: int) -> None:
+        self._connection.execute(f"PRAGMA busy_timeout={busy_timeout_ms:d}")
+        deadline = time.monotonic() + busy_timeout_ms / 1000.0
+        while True:
+            try:
+                self._connection.execute("PRAGMA journal_mode=WAL")
+                break
+            except sqlite3.OperationalError as exc:
+                if not _is_busy_error(exc):
+                    raise
+                if time.monotonic() >= deadline:
+                    raise BackendLockContentionError(
+                        "SQLite database remained busy or locked while enabling WAL "
+                        "beyond busy_timeout; initialization is safe to retry."
+                    ) from exc
+                time.sleep(min(0.01, max(0.0, deadline - time.monotonic())))
+        try:
+            self._connection.execute("PRAGMA synchronous=NORMAL")
+        except sqlite3.OperationalError as exc:
+            if _is_busy_error(exc):
+                raise BackendLockContentionError(
+                    "SQLite database remained busy or locked while configuring "
+                    "synchronous=NORMAL beyond busy_timeout; initialization is "
+                    "safe to retry."
+                ) from exc
+            raise
 
     @contextmanager
     def _transaction(self) -> Iterator[sqlite3.Connection]:

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -125,6 +125,7 @@ class BucketSnapshot:
 class _BucketState:
     spec: BucketSpec
     capacity: float
+    uncapped_capacity: float
     max_capacity: float
     override_active: bool
     is_fresh_start: bool
@@ -164,8 +165,16 @@ def _usage_json(usage: Mapping[str, float]) -> str:
 
 
 def _is_busy_error(exc: sqlite3.OperationalError) -> bool:
-    message = str(exc).lower()
-    return "locked" in message or "busy" in message
+    error_code = getattr(exc, "sqlite_errorcode", None)
+    if isinstance(error_code, int) and error_code & 0xFF in {
+        sqlite3.SQLITE_BUSY,
+        sqlite3.SQLITE_LOCKED,
+    }:
+        return True
+    error_name = getattr(exc, "sqlite_errorname", "")
+    return isinstance(error_name, str) and error_name.startswith(
+        ("SQLITE_BUSY", "SQLITE_LOCKED")
+    )
 
 
 class SqliteEngine:
@@ -199,12 +208,18 @@ class SqliteEngine:
         self._lock = threading.RLock()
         self._closed = False
         try:
-            self._connection = sqlite3.connect(
-                db_path,
-                timeout=busy_timeout_ms / 1000.0,
-                isolation_level=None,
-                check_same_thread=False,
-            )
+            try:
+                self._connection = sqlite3.connect(
+                    db_path,
+                    timeout=busy_timeout_ms / 1000.0,
+                    isolation_level=None,
+                    check_same_thread=False,
+                )
+            except sqlite3.OperationalError as exc:
+                raise sqlite3.OperationalError(
+                    "Unable to open SQLite database at resolved db_path "
+                    f"{db_path!r}: {exc}"
+                ) from exc
             self._configure_connection(busy_timeout_ms)
             self._initialize_schema()
         except BaseException:
@@ -329,6 +344,36 @@ class SqliteEngine:
             for statement in _SCHEMA_STATEMENTS:
                 connection.execute(statement)
 
+    @contextmanager
+    def _read_transaction(
+        self,
+        *,
+        busy_timeout_ms: int | None = None,
+        clock: Callable[[], float] = time.time,
+    ) -> Iterator[tuple[sqlite3.Connection, float]]:
+        with self._lock:
+            operation_timeout_ms = (
+                self._busy_timeout_ms
+                if busy_timeout_ms is None
+                else max(0, min(busy_timeout_ms, self._busy_timeout_ms))
+            )
+            self._connection.execute(f"PRAGMA busy_timeout={operation_timeout_ms:d}")
+            try:
+                self._connection.execute("BEGIN DEFERRED")
+                current_time = clock()
+                yield self._connection, current_time
+                self._connection.execute("COMMIT")
+            except BaseException as exc:
+                with contextlib.suppress(sqlite3.Error):
+                    self._connection.execute("ROLLBACK")
+                if isinstance(exc, sqlite3.OperationalError) and _is_busy_error(exc):
+                    raise BackendLockContentionError(
+                        "SQLite database remained busy or locked beyond "
+                        "busy_timeout while reading; the transaction made no "
+                        "change and is safe to retry."
+                    ) from exc
+                raise
+
     def initialize_buckets(self, clock: Callable[[], float] = time.time) -> None:
         with self._transaction(clock=clock) as (connection, current_time):
             self._prune(connection, current_time)
@@ -374,6 +419,8 @@ class SqliteEngine:
         self,
         connection: sqlite3.Connection,
         current_time: float,
+        *,
+        writable: bool = True,
     ) -> tuple[dict[BucketId, _BucketState], tuple[BucketId, ...]]:
         states: dict[BucketId, _BucketState] = {}
         fresh: list[BucketId] = []
@@ -391,37 +438,39 @@ class SqliteEngine:
                 ),
             ).fetchone()
             if row is not None and float(row[5]) <= current_time:
-                connection.execute(
-                    "DELETE FROM buckets WHERE key_prefix = ? AND model_family = ? "
-                    "AND metric = ? AND per_seconds = ?",
-                    (
-                        self.key_prefix,
-                        self.model_family,
-                        spec.metric,
-                        spec.per_seconds,
-                    ),
-                )
+                if writable:
+                    connection.execute(
+                        "DELETE FROM buckets WHERE key_prefix = ? "
+                        "AND model_family = ? AND metric = ? AND per_seconds = ?",
+                        (
+                            self.key_prefix,
+                            self.model_family,
+                            spec.metric,
+                            spec.per_seconds,
+                        ),
+                    )
                 row = None
             if row is None:
                 override_active = False
                 max_capacity = _validate_max_capacity_finite_positive(
                     spec.configured_max_capacity
                 )
-                connection.execute(
-                    "INSERT INTO buckets "
-                    "(key_prefix, model_family, metric, per_seconds, capacity, "
-                    "last_checked, override_value, override_expires_at, updated_at, "
-                    "expires_at) "
-                    "VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)",
-                    (
-                        self.key_prefix,
-                        self.model_family,
-                        spec.metric,
-                        spec.per_seconds,
-                        current_time,
-                        current_time + self._bucket_ttl_seconds,
-                    ),
-                )
+                if writable:
+                    connection.execute(
+                        "INSERT INTO buckets "
+                        "(key_prefix, model_family, metric, per_seconds, capacity, "
+                        "last_checked, override_value, override_expires_at, "
+                        "updated_at, expires_at) "
+                        "VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)",
+                        (
+                            self.key_prefix,
+                            self.model_family,
+                            spec.metric,
+                            spec.per_seconds,
+                            current_time,
+                            current_time + self._bucket_ttl_seconds,
+                        ),
+                    )
                 capacity_value: float | None = None
                 last_checked_value: float | None = None
             else:
@@ -442,7 +491,9 @@ class SqliteEngine:
                     max_capacity = _validate_max_capacity_finite_positive(
                         spec.configured_max_capacity
                     )
-                    if override_value is not None or override_expires_at is not None:
+                    if writable and (
+                        override_value is not None or override_expires_at is not None
+                    ):
                         connection.execute(
                             "UPDATE buckets SET override_value = NULL, "
                             "override_expires_at = NULL, updated_at = ?, "
@@ -468,21 +519,21 @@ class SqliteEngine:
                 )
                 capacity_value = 0.0
                 last_checked_value = current_time
-                connection.execute(
-                    "UPDATE buckets SET capacity = 0.0, last_checked = ?, "
-                    "updated_at = ?, expires_at = ? WHERE key_prefix = ? "
-                    "AND model_family = ? "
-                    "AND metric = ? AND per_seconds = ?",
-                    (
-                        current_time,
-                        current_time,
-                        current_time + self._bucket_ttl_seconds,
-                        self.key_prefix,
-                        self.model_family,
-                        spec.metric,
-                        spec.per_seconds,
-                    ),
-                )
+                if writable:
+                    connection.execute(
+                        "UPDATE buckets SET capacity = 0.0, last_checked = ?, "
+                        "updated_at = ?, expires_at = ? WHERE key_prefix = ? "
+                        "AND model_family = ? AND metric = ? AND per_seconds = ?",
+                        (
+                            current_time,
+                            current_time,
+                            current_time + self._bucket_ttl_seconds,
+                            self.key_prefix,
+                            self.model_family,
+                            spec.metric,
+                            spec.per_seconds,
+                        ),
+                    )
 
             calculated = calculate_capacity(
                 last_checked=last_checked_value,
@@ -495,11 +546,20 @@ class SqliteEngine:
                 ),
                 bucket_id=self._bucket_log_id(spec),
             )
+            if capacity_value is None or last_checked_value is None:
+                uncapped_capacity = max_capacity
+            else:
+                elapsed = max(0.0, current_time - float(last_checked_value))
+                uncapped_capacity = float(capacity_value) + elapsed * (
+                    _calculate_rate_per_sec(max_capacity, spec.per_seconds)
+                )
+                if not math.isfinite(uncapped_capacity):
+                    uncapped_capacity = max_capacity
             # A persisted wall-clock timestamp far in the future can otherwise
             # survive restarts and suppress refill indefinitely. One second is a
             # narrow tolerance for capture/rounding skew; larger jumps are repaired
             # transactionally while preserving the stored capacity.
-            if (
+            if writable and (
                 last_checked_value is not None
                 and float(last_checked_value)
                 > current_time + FUTURE_LAST_CHECKED_REPAIR_TOLERANCE_SECONDS
@@ -524,6 +584,7 @@ class SqliteEngine:
             states[spec.bucket_id] = _BucketState(
                 spec=spec,
                 capacity=calculated.amount,
+                uncapped_capacity=uncapped_capacity,
                 max_capacity=max_capacity,
                 override_active=override_active,
                 is_fresh_start=calculated.is_fresh_start,
@@ -1017,7 +1078,7 @@ class SqliteEngine:
             if not state.is_fresh_start:
                 self._write_capacities(
                     connection,
-                    {bucket_id: state.capacity},
+                    {bucket_id: state.uncapped_capacity},
                     current_time,
                 )
             connection.execute(
@@ -1050,32 +1111,33 @@ class SqliteEngine:
         bucket_id = (metric, per_seconds)
         if bucket_id not in self._bucket_by_id:
             raise ValueError(f"Bucket '{metric}/{per_seconds}s' not found")
-        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
-            connection,
-            current_time,
-        ):
-            self._prune(connection, current_time)
-            states, _ = self._load_states(connection, current_time)
-            if not states[bucket_id].is_fresh_start:
-                self._write_capacities(
-                    connection,
-                    {bucket_id: states[bucket_id].capacity},
-                    current_time,
+        with self._lock:
+            with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+                connection,
+                current_time,
+            ):
+                self._prune(connection, current_time)
+                states, _ = self._load_states(connection, current_time)
+                if not states[bucket_id].is_fresh_start:
+                    self._write_capacities(
+                        connection,
+                        {bucket_id: states[bucket_id].uncapped_capacity},
+                        current_time,
+                    )
+                connection.execute(
+                    "UPDATE buckets SET override_value = NULL, "
+                    "override_expires_at = NULL, updated_at = ?, expires_at = ? "
+                    "WHERE key_prefix = ? "
+                    "AND model_family = ? AND metric = ? AND per_seconds = ?",
+                    (
+                        current_time,
+                        current_time + self._bucket_ttl_seconds,
+                        self.key_prefix,
+                        self.model_family,
+                        metric,
+                        per_seconds,
+                    ),
                 )
-            connection.execute(
-                "UPDATE buckets SET override_value = NULL, "
-                "override_expires_at = NULL, updated_at = ?, expires_at = ? "
-                "WHERE key_prefix = ? "
-                "AND model_family = ? AND metric = ? AND per_seconds = ?",
-                (
-                    current_time,
-                    current_time + self._bucket_ttl_seconds,
-                    self.key_prefix,
-                    self.model_family,
-                    metric,
-                    per_seconds,
-                ),
-            )
             replacement = BucketSpec(
                 metric=metric,
                 per_seconds=per_seconds,
@@ -1104,7 +1166,7 @@ class SqliteEngine:
             self._prune(connection, current_time)
             states, _ = self._load_states(connection, current_time)
             anchored = {
-                bucket_id: states[bucket_id].capacity
+                bucket_id: states[bucket_id].uncapped_capacity
                 for bucket_id in target_ids
                 if not states[bucket_id].is_fresh_start
             }
@@ -1132,11 +1194,11 @@ class SqliteEngine:
         busy_timeout_ms: int | None = None,
         clock: Callable[[], float] = time.time,
     ) -> tuple[tuple[BucketSnapshot, ...], dict[str, int]]:
-        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+        with self._read_transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
             connection,
             current_time,
         ):
-            states, _ = self._load_states(connection, current_time)
+            states, _ = self._load_states(connection, current_time, writable=False)
             snapshots = tuple(
                 BucketSnapshot(
                     spec=state.spec,

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -327,7 +327,7 @@ class SqliteEngine:
         fresh: list[BucketId] = []
         for spec in self._buckets:
             row = connection.execute(
-                "SELECT capacity, last_checked, max_capacity FROM buckets "
+                "SELECT capacity, last_checked, max_capacity, updated_at FROM buckets "
                 "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
                 "AND per_seconds = ?",
                 (
@@ -337,6 +337,20 @@ class SqliteEngine:
                     spec.per_seconds,
                 ),
             ).fetchone()
+            if row is not None and float(row[3]) <= (
+                current_time - self._bucket_ttl_seconds
+            ):
+                connection.execute(
+                    "DELETE FROM buckets WHERE key_prefix = ? AND model_family = ? "
+                    "AND metric = ? AND per_seconds = ?",
+                    (
+                        self.key_prefix,
+                        self.model_family,
+                        spec.metric,
+                        spec.per_seconds,
+                    ),
+                )
+                row = None
             if row is None:
                 max_capacity = _validate_max_capacity_finite_positive(
                     spec.configured_max_capacity
@@ -447,18 +461,34 @@ class SqliteEngine:
         self,
         connection: sqlite3.Connection,
         reservation_id: str | None,
+        current_time: float,
     ) -> None:
         if reservation_id is None:
             return
         marker = connection.execute(
-            "SELECT 1 FROM acquire_markers WHERE key_prefix = ? AND reservation_id = ?",
-            (self.key_prefix, reservation_id),
-        ).fetchone()
-        tombstone = connection.execute(
-            "SELECT 1 FROM refund_tombstones WHERE key_prefix = ? "
+            "SELECT expires_at FROM acquire_markers WHERE key_prefix = ? "
             "AND reservation_id = ?",
             (self.key_prefix, reservation_id),
         ).fetchone()
+        tombstone = connection.execute(
+            "SELECT expires_at FROM refund_tombstones WHERE key_prefix = ? "
+            "AND reservation_id = ?",
+            (self.key_prefix, reservation_id),
+        ).fetchone()
+        if marker is not None and float(marker[0]) <= current_time:
+            connection.execute(
+                "DELETE FROM acquire_markers WHERE key_prefix = ? "
+                "AND reservation_id = ?",
+                (self.key_prefix, reservation_id),
+            )
+            marker = None
+        if tombstone is not None and float(tombstone[0]) <= current_time:
+            connection.execute(
+                "DELETE FROM refund_tombstones WHERE key_prefix = ? "
+                "AND reservation_id = ?",
+                (self.key_prefix, reservation_id),
+            )
+            tombstone = None
         _debug_event(
             _acquire_logger,
             "sqlite_acquire_marker_read",
@@ -530,7 +560,11 @@ class SqliteEngine:
     ) -> TryConsumeResult:
         with self._transaction() as connection:
             self._prune(connection, current_time)
-            self._raise_if_duplicate_acquire(connection, reservation_id)
+            self._raise_if_duplicate_acquire(
+                connection,
+                reservation_id,
+                current_time,
+            )
             states, fresh = self._load_states(connection, current_time)
             pre = self._capacities(states)
             max_capacities = frozendict(
@@ -594,7 +628,11 @@ class SqliteEngine:
     ) -> CapacityResult:
         with self._transaction() as connection:
             self._prune(connection, current_time)
-            self._raise_if_duplicate_acquire(connection, reservation_id)
+            self._raise_if_duplicate_acquire(
+                connection,
+                reservation_id,
+                current_time,
+            )
             states, fresh = self._load_states(connection, current_time)
             pre = self._capacities(states)
             max_capacities = frozendict(
@@ -625,7 +663,7 @@ class SqliteEngine:
                 fresh_bucket_ids=fresh,
             )
 
-    def _verify_marker(
+    def _verify_marker(  # noqa: PLR0913
         self,
         connection: sqlite3.Connection,
         *,
@@ -633,12 +671,20 @@ class SqliteEngine:
         reservation_model_family: str,
         reservation_bucket_ids: frozenset[BucketId],
         reservation_reserved_usage: FrozenUsage,
+        current_time: float,
     ) -> None:
         tombstone = connection.execute(
-            "SELECT 1 FROM refund_tombstones WHERE key_prefix = ? "
+            "SELECT expires_at FROM refund_tombstones WHERE key_prefix = ? "
             "AND reservation_id = ?",
             (self.key_prefix, reservation_id),
         ).fetchone()
+        if tombstone is not None and float(tombstone[0]) <= current_time:
+            connection.execute(
+                "DELETE FROM refund_tombstones WHERE key_prefix = ? "
+                "AND reservation_id = ?",
+                (self.key_prefix, reservation_id),
+            )
+            tombstone = None
         if tombstone is not None:
             raise DuplicateRefundError(
                 "reservation already refunded",
@@ -647,10 +693,17 @@ class SqliteEngine:
                 model_family=reservation_model_family,
             )
         marker = connection.execute(
-            "SELECT model_family, bucket_ids_json, reserved_usage_json "
+            "SELECT model_family, bucket_ids_json, reserved_usage_json, expires_at "
             "FROM acquire_markers WHERE key_prefix = ? AND reservation_id = ?",
             (self.key_prefix, reservation_id),
         ).fetchone()
+        if marker is not None and float(marker[3]) <= current_time:
+            connection.execute(
+                "DELETE FROM acquire_markers WHERE key_prefix = ? "
+                "AND reservation_id = ?",
+                (self.key_prefix, reservation_id),
+            )
+            marker = None
         _debug_event(
             _refund_logger,
             "sqlite_refund_marker_read",
@@ -708,6 +761,7 @@ class SqliteEngine:
                     reservation_model_family=reservation_model_family,
                     reservation_bucket_ids=reservation_bucket_ids,
                     reservation_reserved_usage=reservation_reserved_usage,
+                    current_time=current_time,
                 )
             states, fresh = self._load_states(connection, current_time)
             pre = self._capacities(states)

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -49,6 +49,7 @@ _SCHEMA_STATEMENTS = (
     override_value REAL,
     override_expires_at REAL,
     updated_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
     PRIMARY KEY (key_prefix, model_family, metric, per_seconds)
 )""",
     """CREATE TABLE IF NOT EXISTS acquire_markers (
@@ -68,7 +69,7 @@ _SCHEMA_STATEMENTS = (
     expires_at REAL NOT NULL,
     PRIMARY KEY (key_prefix, reservation_id)
 )""",
-    "CREATE INDEX IF NOT EXISTS idx_buckets_updated_at ON buckets(updated_at)",
+    "CREATE INDEX IF NOT EXISTS idx_buckets_expires_at ON buckets(expires_at)",
     "CREATE INDEX IF NOT EXISTS idx_acquire_markers_expires_at "
     "ON acquire_markers(expires_at)",
     "CREATE INDEX IF NOT EXISTS idx_refund_tombstones_expires_at "
@@ -327,14 +328,16 @@ class SqliteEngine:
                 connection.execute(
                     "INSERT OR IGNORE INTO buckets "
                     "(key_prefix, model_family, metric, per_seconds, capacity, "
-                    "last_checked, override_value, override_expires_at, updated_at) "
-                    "VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?)",
+                    "last_checked, override_value, override_expires_at, updated_at, "
+                    "expires_at) "
+                    "VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)",
                     (
                         self.key_prefix,
                         self.model_family,
                         bucket.metric,
                         bucket.per_seconds,
                         current_time,
+                        current_time + self._bucket_ttl_seconds,
                     ),
                 )
 
@@ -351,8 +354,8 @@ class SqliteEngine:
         )
         connection.execute(
             "DELETE FROM buckets WHERE rowid IN "
-            "(SELECT rowid FROM buckets WHERE updated_at <= ? LIMIT ?)",
-            (current_time - self._bucket_ttl_seconds, self._prune_batch_size),
+            "(SELECT rowid FROM buckets WHERE expires_at <= ? LIMIT ?)",
+            (current_time, self._prune_batch_size),
         )
 
     def _bucket_log_id(self, bucket: BucketSpec) -> str:
@@ -368,7 +371,7 @@ class SqliteEngine:
         for spec in self._buckets:
             row = connection.execute(
                 "SELECT capacity, last_checked, override_value, "
-                "override_expires_at, updated_at FROM buckets "
+                "override_expires_at, updated_at, expires_at FROM buckets "
                 "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
                 "AND per_seconds = ?",
                 (
@@ -378,9 +381,7 @@ class SqliteEngine:
                     spec.per_seconds,
                 ),
             ).fetchone()
-            if row is not None and float(row[4]) <= (
-                current_time - self._bucket_ttl_seconds
-            ):
+            if row is not None and float(row[5]) <= current_time:
                 connection.execute(
                     "DELETE FROM buckets WHERE key_prefix = ? AND model_family = ? "
                     "AND metric = ? AND per_seconds = ?",
@@ -400,14 +401,16 @@ class SqliteEngine:
                 connection.execute(
                     "INSERT INTO buckets "
                     "(key_prefix, model_family, metric, per_seconds, capacity, "
-                    "last_checked, override_value, override_expires_at, updated_at) "
-                    "VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?)",
+                    "last_checked, override_value, override_expires_at, updated_at, "
+                    "expires_at) "
+                    "VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)",
                     (
                         self.key_prefix,
                         self.model_family,
                         spec.metric,
                         spec.per_seconds,
                         current_time,
+                        current_time + self._bucket_ttl_seconds,
                     ),
                 )
                 capacity_value: float | None = None
@@ -433,9 +436,12 @@ class SqliteEngine:
                     if override_value is not None or override_expires_at is not None:
                         connection.execute(
                             "UPDATE buckets SET override_value = NULL, "
-                            "override_expires_at = NULL WHERE key_prefix = ? "
+                            "override_expires_at = NULL, updated_at = ?, "
+                            "expires_at = ? WHERE key_prefix = ? "
                             "AND model_family = ? AND metric = ? AND per_seconds = ?",
                             (
+                                current_time,
+                                current_time + self._bucket_ttl_seconds,
                                 self.key_prefix,
                                 self.model_family,
                                 spec.metric,
@@ -455,11 +461,13 @@ class SqliteEngine:
                 last_checked_value = current_time
                 connection.execute(
                     "UPDATE buckets SET capacity = 0.0, last_checked = ?, "
-                    "updated_at = ? WHERE key_prefix = ? AND model_family = ? "
+                    "updated_at = ?, expires_at = ? WHERE key_prefix = ? "
+                    "AND model_family = ? "
                     "AND metric = ? AND per_seconds = ?",
                     (
                         current_time,
                         current_time,
+                        current_time + self._bucket_ttl_seconds,
                         self.key_prefix,
                         self.model_family,
                         spec.metric,
@@ -488,12 +496,14 @@ class SqliteEngine:
                 > current_time + FUTURE_LAST_CHECKED_REPAIR_TOLERANCE_SECONDS
             ):
                 connection.execute(
-                    "UPDATE buckets SET last_checked = ?, updated_at = ? "
+                    "UPDATE buckets SET last_checked = ?, updated_at = ?, "
+                    "expires_at = ? "
                     "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
                     "AND per_seconds = ?",
                     (
                         current_time,
                         current_time,
+                        current_time + self._bucket_ttl_seconds,
                         self.key_prefix,
                         self.model_family,
                         spec.metric,
@@ -528,13 +538,15 @@ class SqliteEngine:
                 raise ValueError(f"capacity must be finite (got {amount!r})")
             normalized = 0.0 if float(amount) == 0.0 else float(amount)
             cursor = connection.execute(
-                "UPDATE buckets SET capacity = ?, last_checked = ?, updated_at = ? "
+                "UPDATE buckets SET capacity = ?, last_checked = ?, updated_at = ?, "
+                "expires_at = ? "
                 "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
                 "AND per_seconds = ?",
                 (
                     normalized,
                     current_time,
                     current_time,
+                    current_time + self._bucket_ttl_seconds,
                     self.key_prefix,
                     self.model_family,
                     metric,
@@ -988,13 +1000,14 @@ class SqliteEngine:
                 )
             connection.execute(
                 "UPDATE buckets SET override_value = ?, override_expires_at = ?, "
-                "updated_at = ? "
+                "updated_at = ?, expires_at = ? "
                 "WHERE key_prefix = ? "
                 "AND model_family = ? AND metric = ? AND per_seconds = ?",
                 (
                     value,
                     current_time + self._override_ttl_seconds,
                     current_time,
+                    current_time + self._bucket_ttl_seconds,
                     self.key_prefix,
                     self.model_family,
                     metric,
@@ -1026,9 +1039,12 @@ class SqliteEngine:
                 )
             connection.execute(
                 "UPDATE buckets SET override_value = NULL, "
-                "override_expires_at = NULL WHERE key_prefix = ? "
+                "override_expires_at = NULL, updated_at = ?, expires_at = ? "
+                "WHERE key_prefix = ? "
                 "AND model_family = ? AND metric = ? AND per_seconds = ?",
                 (
+                    current_time,
+                    current_time + self._bucket_ttl_seconds,
                     self.key_prefix,
                     self.model_family,
                     metric,
@@ -1069,9 +1085,12 @@ class SqliteEngine:
             for metric, per_seconds in target_ids:
                 connection.execute(
                     "UPDATE buckets SET override_value = NULL, "
-                    "override_expires_at = NULL WHERE key_prefix = ? "
+                    "override_expires_at = NULL, updated_at = ?, expires_at = ? "
+                    "WHERE key_prefix = ? "
                     "AND model_family = ? AND metric = ? AND per_seconds = ?",
                     (
+                        current_time,
+                        current_time + self._bucket_ttl_seconds,
                         self.key_prefix,
                         self.model_family,
                         metric,

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -25,7 +25,7 @@ from token_throttle._exceptions import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Callable, Iterator, Mapping
 
     from token_throttle._interfaces._models import BucketId, Capacities, FrozenUsage
 
@@ -271,7 +271,8 @@ class SqliteEngine:
         *,
         busy_timeout_ms: int | None = None,
         timeout_on_busy: bool = False,
-    ) -> Iterator[sqlite3.Connection]:
+        clock: Callable[[], float] = time.time,
+    ) -> Iterator[tuple[sqlite3.Connection, float]]:
         with self._lock:
             operation_timeout_ms = (
                 self._busy_timeout_ms
@@ -284,7 +285,11 @@ class SqliteEngine:
             self._connection.execute(f"PRAGMA busy_timeout={operation_timeout_ms:d}")
             try:
                 self._connection.execute("BEGIN IMMEDIATE")
-                yield self._connection
+                # Wall time is transaction state: sampling only after the SQLite
+                # write lock is held prevents lock-wait staleness from moving a
+                # bucket's persisted clock backwards.
+                current_time = clock()
+                yield self._connection, current_time
                 self._connection.execute("COMMIT")
             except BaseException as exc:
                 with contextlib.suppress(sqlite3.Error):
@@ -302,7 +307,7 @@ class SqliteEngine:
                 raise
 
     def _initialize_schema(self) -> None:
-        with self._transaction() as connection:
+        with self._transaction() as (connection, _current_time):
             connection.execute(
                 "CREATE TABLE IF NOT EXISTS meta "
                 "(key TEXT PRIMARY KEY, value TEXT NOT NULL)"
@@ -324,8 +329,8 @@ class SqliteEngine:
             for statement in _SCHEMA_STATEMENTS:
                 connection.execute(statement)
 
-    def initialize_buckets(self, current_time: float) -> None:
-        with self._transaction() as connection:
+    def initialize_buckets(self, clock: Callable[[], float] = time.time) -> None:
+        with self._transaction(clock=clock) as (connection, current_time):
             self._prune(connection, current_time)
             for bucket in self._buckets:
                 _validate_max_capacity_finite_positive(bucket.configured_max_capacity)
@@ -660,16 +665,17 @@ class SqliteEngine:
         self,
         usage: FrozenUsage,
         *,
-        current_time: float,
         reservation_id: str | None,
         reservation_lifetime_seconds: float | None,
         busy_timeout_ms: int | None = None,
         timeout_on_busy: bool = False,
+        clock: Callable[[], float] = time.time,
     ) -> TryConsumeResult:
         with self._transaction(
             busy_timeout_ms=busy_timeout_ms,
             timeout_on_busy=timeout_on_busy,
-        ) as connection:
+            clock=clock,
+        ) as (connection, current_time):
             self._prune(connection, current_time)
             self._raise_if_duplicate_acquire(
                 connection,
@@ -733,12 +739,15 @@ class SqliteEngine:
         self,
         usage: FrozenUsage,
         *,
-        current_time: float,
         reservation_id: str | None,
         reservation_lifetime_seconds: float | None,
         busy_timeout_ms: int | None = None,
+        clock: Callable[[], float] = time.time,
     ) -> CapacityResult:
-        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+            connection,
+            current_time,
+        ):
             self._prune(connection, current_time)
             self._raise_if_duplicate_acquire(
                 connection,
@@ -843,12 +852,12 @@ class SqliteEngine:
         actual_usage: FrozenUsage,
         *,
         refund_bucket_ids: frozenset[BucketId],
-        current_time: float,
         reservation_id: str | None,
         reservation_model_family: str | None,
         reservation_bucket_ids: frozenset[BucketId] | None,
         reservation_reserved_usage: FrozenUsage | None,
         busy_timeout_ms: int | None = None,
+        clock: Callable[[], float] = time.time,
     ) -> RefundResult:
         refund_usage = frozendict(
             {
@@ -856,7 +865,10 @@ class SqliteEngine:
                 for metric, amount in reserved_usage.items()
             }
         )
-        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+            connection,
+            current_time,
+        ):
             self._prune(connection, current_time)
             if reservation_id is not None:
                 if (
@@ -939,11 +951,14 @@ class SqliteEngine:
         usage: FrozenUsage,
         *,
         bucket_ids: frozenset[BucketId],
-        current_time: float,
         reservation_id: str | None,
         busy_timeout_ms: int | None = None,
+        clock: Callable[[], float] = time.time,
     ) -> None:
-        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+            connection,
+            current_time,
+        ):
             self._prune(connection, current_time)
             if reservation_id is not None:
                 marker = connection.execute(
@@ -985,14 +1000,17 @@ class SqliteEngine:
         per_seconds: int,
         value: float,
         *,
-        current_time: float,
         busy_timeout_ms: int | None = None,
+        clock: Callable[[], float] = time.time,
     ) -> None:
         value = _validate_max_capacity_finite_positive(value)
         bucket_id = (metric, per_seconds)
         if bucket_id not in self._bucket_by_id:
             raise ValueError(f"Bucket '{metric}/{per_seconds}s' not found")
-        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+            connection,
+            current_time,
+        ):
             self._prune(connection, current_time)
             states, _ = self._load_states(connection, current_time)
             state = states[bucket_id]
@@ -1025,14 +1043,17 @@ class SqliteEngine:
         per_seconds: int,
         value: float,
         *,
-        current_time: float,
         busy_timeout_ms: int | None = None,
+        clock: Callable[[], float] = time.time,
     ) -> None:
         value = _validate_max_capacity_finite_positive(value)
         bucket_id = (metric, per_seconds)
         if bucket_id not in self._bucket_by_id:
             raise ValueError(f"Bucket '{metric}/{per_seconds}s' not found")
-        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+            connection,
+            current_time,
+        ):
             self._prune(connection, current_time)
             states, _ = self._load_states(connection, current_time)
             if not states[bucket_id].is_fresh_start:
@@ -1070,13 +1091,16 @@ class SqliteEngine:
         self,
         bucket_ids: frozenset[BucketId],
         *,
-        current_time: float,
         busy_timeout_ms: int | None = None,
+        clock: Callable[[], float] = time.time,
     ) -> None:
         target_ids = bucket_ids.intersection(self.bucket_ids)
         if not target_ids:
             return
-        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+            connection,
+            current_time,
+        ):
             self._prune(connection, current_time)
             states, _ = self._load_states(connection, current_time)
             anchored = {
@@ -1105,10 +1129,13 @@ class SqliteEngine:
     def inspect_snapshot(
         self,
         *,
-        current_time: float,
         busy_timeout_ms: int | None = None,
+        clock: Callable[[], float] = time.time,
     ) -> tuple[tuple[BucketSnapshot, ...], dict[str, int]]:
-        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms, clock=clock) as (
+            connection,
+            current_time,
+        ):
             states, _ = self._load_states(connection, current_time)
             snapshots = tuple(
                 BucketSnapshot(

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -1064,6 +1064,13 @@ class SqliteEngine:
         busy_timeout_ms: int | None = None,
         clock: Callable[[], float] = time.time,
     ) -> None:
+        """
+        Persist a runtime cap after anchoring state at the old refill rate.
+
+        The anchor deliberately keeps the uncapped integration. Reads cap the
+        visible amount, but preserving raw overflow makes lower-then-raise cap
+        sequences recoverable when no intervening capacity write occurred.
+        """
         value = _validate_max_capacity_finite_positive(value)
         bucket_id = (metric, per_seconds)
         if bucket_id not in self._bucket_by_id:

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 SCHEMA_VERSION: Final[int] = 1
 DEFAULT_BUSY_TIMEOUT_MS: Final[int] = 5000
 DEFAULT_PRUNE_BATCH_SIZE: Final[int] = 256
+FUTURE_LAST_CHECKED_REPAIR_TOLERANCE_SECONDS: Final[float] = 1.0
 
 _acquire_logger = logging.getLogger("token_throttle.acquire")
 _refund_logger = logging.getLogger("token_throttle.refund")
@@ -45,7 +46,8 @@ _SCHEMA_STATEMENTS = (
     per_seconds INTEGER NOT NULL,
     capacity REAL,
     last_checked REAL,
-    max_capacity REAL NOT NULL,
+    override_value REAL,
+    override_expires_at REAL,
     updated_at REAL NOT NULL,
     PRIMARY KEY (key_prefix, model_family, metric, per_seconds)
 )""",
@@ -110,10 +112,20 @@ class RefundResult:
 
 
 @dataclass(frozen=True, slots=True)
+class BucketSnapshot:
+    spec: BucketSpec
+    current_capacity: float
+    effective_max_capacity: float
+    override_active: bool
+    is_fresh_start: bool
+
+
+@dataclass(frozen=True, slots=True)
 class _BucketState:
     spec: BucketSpec
     capacity: float
     max_capacity: float
+    override_active: bool
     is_fresh_start: bool
 
 
@@ -167,6 +179,7 @@ class SqliteEngine:
         buckets: tuple[BucketSpec, ...],
         bucket_ttl_seconds: int,
         refund_dedup_ttl_seconds: int,
+        override_ttl_seconds: int,
         max_reservation_lifetime_seconds: float,
         busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
         prune_batch_size: int = DEFAULT_PRUNE_BATCH_SIZE,
@@ -178,7 +191,9 @@ class SqliteEngine:
         self._bucket_by_id = {bucket.bucket_id: bucket for bucket in buckets}
         self._bucket_ttl_seconds = bucket_ttl_seconds
         self._refund_dedup_ttl_seconds = refund_dedup_ttl_seconds
+        self._override_ttl_seconds = override_ttl_seconds
         self._max_reservation_lifetime_seconds = max_reservation_lifetime_seconds
+        self._busy_timeout_ms = busy_timeout_ms
         self._prune_batch_size = prune_batch_size
         self._lock = threading.RLock()
         try:
@@ -203,6 +218,16 @@ class SqliteEngine:
     @property
     def metric_names(self) -> set[str]:
         return {bucket.metric for bucket in self._buckets}
+
+    @property
+    def busy_timeout_ms(self) -> int:
+        return self._busy_timeout_ms
+
+    def configured_max_capacity(self, metric: str, per_seconds: int) -> float:
+        try:
+            return self._bucket_by_id[(metric, per_seconds)].configured_max_capacity
+        except KeyError as exc:
+            raise ValueError(f"Bucket '{metric}/{per_seconds}s' not found") from exc
 
     def close(self) -> None:
         with self._lock:
@@ -236,8 +261,22 @@ class SqliteEngine:
             raise
 
     @contextmanager
-    def _transaction(self) -> Iterator[sqlite3.Connection]:
+    def _transaction(
+        self,
+        *,
+        busy_timeout_ms: int | None = None,
+        timeout_on_busy: bool = False,
+    ) -> Iterator[sqlite3.Connection]:
         with self._lock:
+            operation_timeout_ms = (
+                self._busy_timeout_ms
+                if busy_timeout_ms is None
+                else max(0, min(busy_timeout_ms, self._busy_timeout_ms))
+            )
+            # This connection is shared by all engine operations. Set the
+            # deadline-derived timeout before every operation; the next operation
+            # will replace it, so there is no stale timeout to restore.
+            self._connection.execute(f"PRAGMA busy_timeout={operation_timeout_ms:d}")
             try:
                 self._connection.execute("BEGIN IMMEDIATE")
                 yield self._connection
@@ -246,6 +285,10 @@ class SqliteEngine:
                 with contextlib.suppress(sqlite3.Error):
                     self._connection.execute("ROLLBACK")
                 if isinstance(exc, sqlite3.OperationalError) and _is_busy_error(exc):
+                    if timeout_on_busy:
+                        raise TimeoutError(
+                            "Timed out waiting for SQLite write-lock contention"
+                        ) from exc
                     raise BackendLockContentionError(
                         "SQLite database remained busy or locked beyond "
                         "busy_timeout; the transaction made no change and is safe "
@@ -280,20 +323,17 @@ class SqliteEngine:
         with self._transaction() as connection:
             self._prune(connection, current_time)
             for bucket in self._buckets:
-                max_capacity = _validate_max_capacity_finite_positive(
-                    bucket.configured_max_capacity
-                )
+                _validate_max_capacity_finite_positive(bucket.configured_max_capacity)
                 connection.execute(
                     "INSERT OR IGNORE INTO buckets "
                     "(key_prefix, model_family, metric, per_seconds, capacity, "
-                    "last_checked, max_capacity, updated_at) "
-                    "VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
+                    "last_checked, override_value, override_expires_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?)",
                     (
                         self.key_prefix,
                         self.model_family,
                         bucket.metric,
                         bucket.per_seconds,
-                        max_capacity,
                         current_time,
                     ),
                 )
@@ -327,7 +367,8 @@ class SqliteEngine:
         fresh: list[BucketId] = []
         for spec in self._buckets:
             row = connection.execute(
-                "SELECT capacity, last_checked, max_capacity, updated_at FROM buckets "
+                "SELECT capacity, last_checked, override_value, "
+                "override_expires_at, updated_at FROM buckets "
                 "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
                 "AND per_seconds = ?",
                 (
@@ -337,7 +378,7 @@ class SqliteEngine:
                     spec.per_seconds,
                 ),
             ).fetchone()
-            if row is not None and float(row[3]) <= (
+            if row is not None and float(row[4]) <= (
                 current_time - self._bucket_ttl_seconds
             ):
                 connection.execute(
@@ -352,20 +393,20 @@ class SqliteEngine:
                 )
                 row = None
             if row is None:
+                override_active = False
                 max_capacity = _validate_max_capacity_finite_positive(
                     spec.configured_max_capacity
                 )
                 connection.execute(
                     "INSERT INTO buckets "
                     "(key_prefix, model_family, metric, per_seconds, capacity, "
-                    "last_checked, max_capacity, updated_at) "
-                    "VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
+                    "last_checked, override_value, override_expires_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, NULL, NULL, NULL, NULL, ?)",
                     (
                         self.key_prefix,
                         self.model_family,
                         spec.metric,
                         spec.per_seconds,
-                        max_capacity,
                         current_time,
                     ),
                 )
@@ -374,7 +415,33 @@ class SqliteEngine:
             else:
                 capacity_value = row[0]
                 last_checked_value = row[1]
-                max_capacity = _validate_max_capacity_finite_positive(row[2])
+                override_value = row[2]
+                override_expires_at = row[3]
+                override_active = (
+                    override_value is not None
+                    and override_expires_at is not None
+                    and float(override_expires_at) > current_time
+                )
+                if override_active:
+                    max_capacity = _validate_max_capacity_finite_positive(
+                        override_value
+                    )
+                else:
+                    max_capacity = _validate_max_capacity_finite_positive(
+                        spec.configured_max_capacity
+                    )
+                    if override_value is not None or override_expires_at is not None:
+                        connection.execute(
+                            "UPDATE buckets SET override_value = NULL, "
+                            "override_expires_at = NULL WHERE key_prefix = ? "
+                            "AND model_family = ? AND metric = ? AND per_seconds = ?",
+                            (
+                                self.key_prefix,
+                                self.model_family,
+                                spec.metric,
+                                spec.per_seconds,
+                            ),
+                        )
 
             if (capacity_value is None) != (last_checked_value is None):
                 _logger.warning(
@@ -411,12 +478,35 @@ class SqliteEngine:
                 ),
                 bucket_id=self._bucket_log_id(spec),
             )
+            # A persisted wall-clock timestamp far in the future can otherwise
+            # survive restarts and suppress refill indefinitely. One second is a
+            # narrow tolerance for capture/rounding skew; larger jumps are repaired
+            # transactionally while preserving the stored capacity.
+            if (
+                last_checked_value is not None
+                and float(last_checked_value)
+                > current_time + FUTURE_LAST_CHECKED_REPAIR_TOLERANCE_SECONDS
+            ):
+                connection.execute(
+                    "UPDATE buckets SET last_checked = ?, updated_at = ? "
+                    "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
+                    "AND per_seconds = ?",
+                    (
+                        current_time,
+                        current_time,
+                        self.key_prefix,
+                        self.model_family,
+                        spec.metric,
+                        spec.per_seconds,
+                    ),
+                )
             if calculated.is_fresh_start:
                 fresh.append(spec.bucket_id)
             states[spec.bucket_id] = _BucketState(
                 spec=spec,
                 capacity=calculated.amount,
                 max_capacity=max_capacity,
+                override_active=override_active,
                 is_fresh_start=calculated.is_fresh_start,
             )
         return states, tuple(fresh)
@@ -550,15 +640,20 @@ class SqliteEngine:
             ),
         )
 
-    def try_consume(
+    def try_consume(  # noqa: PLR0913
         self,
         usage: FrozenUsage,
         *,
         current_time: float,
         reservation_id: str | None,
         reservation_lifetime_seconds: float | None,
+        busy_timeout_ms: int | None = None,
+        timeout_on_busy: bool = False,
     ) -> TryConsumeResult:
-        with self._transaction() as connection:
+        with self._transaction(
+            busy_timeout_ms=busy_timeout_ms,
+            timeout_on_busy=timeout_on_busy,
+        ) as connection:
             self._prune(connection, current_time)
             self._raise_if_duplicate_acquire(
                 connection,
@@ -625,8 +720,9 @@ class SqliteEngine:
         current_time: float,
         reservation_id: str | None,
         reservation_lifetime_seconds: float | None,
+        busy_timeout_ms: int | None = None,
     ) -> CapacityResult:
-        with self._transaction() as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
             self._prune(connection, current_time)
             self._raise_if_duplicate_acquire(
                 connection,
@@ -736,6 +832,7 @@ class SqliteEngine:
         reservation_model_family: str | None,
         reservation_bucket_ids: frozenset[BucketId] | None,
         reservation_reserved_usage: FrozenUsage | None,
+        busy_timeout_ms: int | None = None,
     ) -> RefundResult:
         refund_usage = frozendict(
             {
@@ -743,7 +840,7 @@ class SqliteEngine:
                 for metric, amount in reserved_usage.items()
             }
         )
-        with self._transaction() as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
             self._prune(connection, current_time)
             if reservation_id is not None:
                 if (
@@ -828,8 +925,9 @@ class SqliteEngine:
         bucket_ids: frozenset[BucketId],
         current_time: float,
         reservation_id: str | None,
+        busy_timeout_ms: int | None = None,
     ) -> None:
-        with self._transaction() as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
             self._prune(connection, current_time)
             if reservation_id is not None:
                 marker = connection.execute(
@@ -872,75 +970,30 @@ class SqliteEngine:
         value: float,
         *,
         current_time: float,
+        busy_timeout_ms: int | None = None,
     ) -> None:
         value = _validate_max_capacity_finite_positive(value)
         bucket_id = (metric, per_seconds)
         if bucket_id not in self._bucket_by_id:
             raise ValueError(f"Bucket '{metric}/{per_seconds}s' not found")
-        spec = self._bucket_by_id[bucket_id]
-        with self._transaction() as connection:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
             self._prune(connection, current_time)
-            row = connection.execute(
-                "SELECT capacity, last_checked, max_capacity FROM buckets "
-                "WHERE key_prefix = ? AND model_family = ? AND metric = ? "
-                "AND per_seconds = ?",
-                (
-                    self.key_prefix,
-                    self.model_family,
-                    metric,
-                    per_seconds,
-                ),
-            ).fetchone()
-            if row is None:
-                connection.execute(
-                    "INSERT INTO buckets "
-                    "(key_prefix, model_family, metric, per_seconds, capacity, "
-                    "last_checked, max_capacity, updated_at) "
-                    "VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)",
-                    (
-                        self.key_prefix,
-                        self.model_family,
-                        metric,
-                        per_seconds,
-                        value,
-                        current_time,
-                    ),
+            states, _ = self._load_states(connection, current_time)
+            state = states[bucket_id]
+            if not state.is_fresh_start:
+                self._write_capacities(
+                    connection,
+                    {bucket_id: state.capacity},
+                    current_time,
                 )
-                return
-            capacity, last_checked, old_max = row
-            old_max = _validate_max_capacity_finite_positive(old_max)
-            if (capacity is None) != (last_checked is None):
-                capacity = 0.0
-                last_checked = current_time
-            if capacity is not None and last_checked is not None:
-                calculate_capacity(
-                    last_checked=last_checked,
-                    outdated_capacity=capacity,
-                    current_time=current_time,
-                    max_capacity=old_max,
-                    rate_per_sec=_calculate_rate_per_sec(
-                        old_max,
-                        spec.per_seconds,
-                    ),
-                    bucket_id=self._bucket_log_id(spec),
-                )
-                elapsed = max(0.0, current_time - float(last_checked))
-                anchored = float(capacity) + elapsed * _calculate_rate_per_sec(
-                    old_max,
-                    spec.per_seconds,
-                )
-                if not math.isfinite(anchored):
-                    anchored = old_max
-                capacity = anchored
-                last_checked = current_time
             connection.execute(
-                "UPDATE buckets SET capacity = ?, last_checked = ?, "
-                "max_capacity = ?, updated_at = ? WHERE key_prefix = ? "
+                "UPDATE buckets SET override_value = ?, override_expires_at = ?, "
+                "updated_at = ? "
+                "WHERE key_prefix = ? "
                 "AND model_family = ? AND metric = ? AND per_seconds = ?",
                 (
-                    capacity,
-                    last_checked,
                     value,
+                    current_time + self._override_ttl_seconds,
                     current_time,
                     self.key_prefix,
                     self.model_family,
@@ -949,26 +1002,128 @@ class SqliteEngine:
                 ),
             )
 
+    def apply_configured_max_capacity(
+        self,
+        metric: str,
+        per_seconds: int,
+        value: float,
+        *,
+        current_time: float,
+        busy_timeout_ms: int | None = None,
+    ) -> None:
+        value = _validate_max_capacity_finite_positive(value)
+        bucket_id = (metric, per_seconds)
+        if bucket_id not in self._bucket_by_id:
+            raise ValueError(f"Bucket '{metric}/{per_seconds}s' not found")
+        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+            self._prune(connection, current_time)
+            states, _ = self._load_states(connection, current_time)
+            if not states[bucket_id].is_fresh_start:
+                self._write_capacities(
+                    connection,
+                    {bucket_id: states[bucket_id].capacity},
+                    current_time,
+                )
+            connection.execute(
+                "UPDATE buckets SET override_value = NULL, "
+                "override_expires_at = NULL WHERE key_prefix = ? "
+                "AND model_family = ? AND metric = ? AND per_seconds = ?",
+                (
+                    self.key_prefix,
+                    self.model_family,
+                    metric,
+                    per_seconds,
+                ),
+            )
+            replacement = BucketSpec(
+                metric=metric,
+                per_seconds=per_seconds,
+                configured_max_capacity=value,
+            )
+            self._bucket_by_id[bucket_id] = replacement
+            self._buckets = tuple(
+                replacement if spec.bucket_id == bucket_id else spec
+                for spec in self._buckets
+            )
+
+    def clear_max_capacity_overrides(
+        self,
+        bucket_ids: frozenset[BucketId],
+        *,
+        current_time: float,
+        busy_timeout_ms: int | None = None,
+    ) -> None:
+        target_ids = bucket_ids.intersection(self.bucket_ids)
+        if not target_ids:
+            return
+        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+            self._prune(connection, current_time)
+            states, _ = self._load_states(connection, current_time)
+            anchored = {
+                bucket_id: states[bucket_id].capacity
+                for bucket_id in target_ids
+                if not states[bucket_id].is_fresh_start
+            }
+            if anchored:
+                self._write_capacities(connection, anchored, current_time)
+            for metric, per_seconds in target_ids:
+                connection.execute(
+                    "UPDATE buckets SET override_value = NULL, "
+                    "override_expires_at = NULL WHERE key_prefix = ? "
+                    "AND model_family = ? AND metric = ? AND per_seconds = ?",
+                    (
+                        self.key_prefix,
+                        self.model_family,
+                        metric,
+                        per_seconds,
+                    ),
+                )
+
+    def inspect_snapshot(
+        self,
+        *,
+        current_time: float,
+        busy_timeout_ms: int | None = None,
+    ) -> tuple[tuple[BucketSnapshot, ...], dict[str, int]]:
+        with self._transaction(busy_timeout_ms=busy_timeout_ms) as connection:
+            states, _ = self._load_states(connection, current_time)
+            snapshots = tuple(
+                BucketSnapshot(
+                    spec=state.spec,
+                    current_capacity=state.capacity,
+                    effective_max_capacity=state.max_capacity,
+                    override_active=state.override_active,
+                    is_fresh_start=state.is_fresh_start,
+                )
+                for state in states.values()
+            )
+            counts = self._inspect_counts_locked(connection)
+        return snapshots, counts
+
+    def _inspect_counts_locked(self, connection: sqlite3.Connection) -> dict[str, int]:
+        return {
+            "buckets": int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM buckets WHERE key_prefix = ?",
+                    (self.key_prefix,),
+                ).fetchone()[0]
+            ),
+            "acquire_markers": int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM acquire_markers WHERE key_prefix = ?",
+                    (self.key_prefix,),
+                ).fetchone()[0]
+            ),
+            "refund_tombstones": int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM refund_tombstones WHERE key_prefix = ?",
+                    (self.key_prefix,),
+                ).fetchone()[0]
+            ),
+        }
+
     def inspect_counts(self) -> dict[str, int]:
         """Return scoped row counts for deterministic backend-specific tests."""
         with self._lock:
-            return {
-                "buckets": int(
-                    self._connection.execute(
-                        "SELECT COUNT(*) FROM buckets WHERE key_prefix = ?",
-                        (self.key_prefix,),
-                    ).fetchone()[0]
-                ),
-                "acquire_markers": int(
-                    self._connection.execute(
-                        "SELECT COUNT(*) FROM acquire_markers WHERE key_prefix = ?",
-                        (self.key_prefix,),
-                    ).fetchone()[0]
-                ),
-                "refund_tombstones": int(
-                    self._connection.execute(
-                        "SELECT COUNT(*) FROM refund_tombstones WHERE key_prefix = ?",
-                        (self.key_prefix,),
-                    ).fetchone()[0]
-                ),
-            }
+            self._connection.execute(f"PRAGMA busy_timeout={self._busy_timeout_ms:d}")
+            return self._inspect_counts_locked(self._connection)

--- a/token_throttle/_limiter_backends/_sqlite/_engine.py
+++ b/token_throttle/_limiter_backends/_sqlite/_engine.py
@@ -197,6 +197,7 @@ class SqliteEngine:
         self._busy_timeout_ms = busy_timeout_ms
         self._prune_batch_size = prune_batch_size
         self._lock = threading.RLock()
+        self._closed = False
         try:
             self._connection = sqlite3.connect(
                 db_path,
@@ -232,6 +233,9 @@ class SqliteEngine:
 
     def close(self) -> None:
         with self._lock:
+            if self._closed:
+                return
+            self._closed = True
             self._connection.close()
 
     def _configure_connection(self, busy_timeout_ms: int) -> None:

--- a/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
@@ -16,8 +16,8 @@ from token_throttle._capacity import _validate_max_capacity_finite_positive
 from token_throttle._diagnostic import (
     BackendBucketLimit,
     BackendIntrospectionDiagnostic,
-    DiagnosticIssue,
     DiagnosticWaiterState,
+    SqliteBackendHealthDiagnostic,
     backend_type_for_object,
     make_bucket_diagnostic,
     wait_bucket_diagnostics,
@@ -334,7 +334,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
 
     def introspect(self) -> BackendIntrospectionDiagnostic:
         as_of_monotonic = time.monotonic()
-        issues: list[DiagnosticIssue] = []
         snapshots, counts = self._engine.inspect_snapshot(current_time=time.time())
         buckets = tuple(
             make_bucket_diagnostic(
@@ -350,21 +349,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
                 as_of_monotonic=as_of_monotonic,
             )
             for snapshot in snapshots
-        )
-        # Diagnostic schema v1 has no SQLite health DTO. Preserve the first-party
-        # backend's honest "custom" classification and surface exact durable counts
-        # in its existing structured issue channel until a schema revision exists.
-        issues.append(
-            DiagnosticIssue(
-                severity="info",
-                component="sqlite_backend",
-                message=(
-                    "durable rows: "
-                    f"acquire_markers={counts['acquire_markers']}, "
-                    f"refund_tombstones={counts['refund_tombstones']}"
-                ),
-                model_family=self._engine.model_family,
-            )
         )
         with self._diagnostic_lock:
             waiters = tuple(
@@ -382,7 +366,13 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
             waits=waiters,
             memory_health=None,
             redis_health=None,
-            issues=tuple(issues),
+            sqlite_health=SqliteBackendHealthDiagnostic(
+                model_family_count=1,
+                bucket_count=len(buckets),
+                acquire_marker_count=counts["acquire_markers"],
+                refund_tombstone_count=counts["refund_tombstones"],
+            ),
+            issues=(),
         )
 
     def prepare_reconfigured_backend(

--- a/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
@@ -6,12 +6,23 @@ import os
 import random
 import threading
 import time
+import uuid
 import warnings
 from typing import TYPE_CHECKING, ClassVar
 
 from frozendict import frozendict
 
 from token_throttle._capacity import _validate_max_capacity_finite_positive
+from token_throttle._diagnostic import (
+    BackendBucketLimit,
+    BackendIntrospectionDiagnostic,
+    DiagnosticIssue,
+    DiagnosticWaiterState,
+    backend_type_for_object,
+    make_bucket_diagnostic,
+    wait_bucket_diagnostics,
+    waiter_diagnostic_from_state,
+)
 from token_throttle._exceptions import BackendLockContentionError
 from token_throttle._interfaces._callbacks import (
     BACKEND_CALLBACK_CRITICAL_EXCEPTIONS,
@@ -163,6 +174,7 @@ class SyncSqliteBackendBuilder(SyncRateLimiterBackendBuilderInterface):
         sleep_interval: float | None = None,
         bucket_ttl_seconds: int = DEFAULT_BUCKET_TTL_SECONDS,
         refund_dedup_ttl_seconds: int = DEFAULT_REFUND_DEDUP_TTL_SECONDS,
+        override_ttl_seconds: int | None = None,
         max_reservation_lifetime_seconds: float | None = None,
         busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
         prune_batch_size: int = DEFAULT_PRUNE_BATCH_SIZE,
@@ -178,6 +190,14 @@ class SyncSqliteBackendBuilder(SyncRateLimiterBackendBuilderInterface):
         self._refund_dedup_ttl_seconds = validate_sqlite_ttl_seconds(
             refund_dedup_ttl_seconds,
             name="refund_dedup_ttl_seconds",
+        )
+        self._override_ttl_seconds = validate_sqlite_ttl_seconds(
+            (
+                self._bucket_ttl_seconds
+                if override_ttl_seconds is None
+                else override_ttl_seconds
+            ),
+            name="override_ttl_seconds",
         )
         self._max_reservation_lifetime_seconds = (
             resolve_max_reservation_lifetime_seconds_from_ttls(
@@ -250,6 +270,7 @@ class SyncSqliteBackendBuilder(SyncRateLimiterBackendBuilderInterface):
             ),
             bucket_ttl_seconds=self._bucket_ttl_seconds,
             refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+            override_ttl_seconds=self._override_ttl_seconds,
             max_reservation_lifetime_seconds=(self._max_reservation_lifetime_seconds),
             busy_timeout_ms=self._busy_timeout_ms,
             prune_batch_size=self._prune_batch_size,
@@ -295,6 +316,8 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
         if callbacks is not None:
             _revalidate_dto(callbacks)
         self._callbacks = callbacks
+        self._diagnostic_waiters: dict[str, DiagnosticWaiterState] = {}
+        self._diagnostic_lock = threading.Lock()
         validated_sleep = validate_sleep_interval(sleep_interval)
         self._sleep_interval = (
             self.DEFAULT_SLEEP_INTERVAL if validated_sleep is None else validated_sleep
@@ -309,10 +332,63 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
     def supports_acquire_marker_authority(self) -> bool:
         return True
 
+    def introspect(self) -> BackendIntrospectionDiagnostic:
+        as_of_monotonic = time.monotonic()
+        issues: list[DiagnosticIssue] = []
+        snapshots, counts = self._engine.inspect_snapshot(current_time=time.time())
+        buckets = tuple(
+            make_bucket_diagnostic(
+                model_family=self._engine.model_family,
+                metric=snapshot.spec.metric,
+                per_seconds=snapshot.spec.per_seconds,
+                backend_type=backend_type_for_object(self),
+                current_capacity=snapshot.current_capacity,
+                configured_limit=snapshot.spec.configured_max_capacity,
+                effective_max_capacity=snapshot.effective_max_capacity,
+                override_source=("backend" if snapshot.override_active else "none"),
+                status="fresh_start" if snapshot.is_fresh_start else "ok",
+                as_of_monotonic=as_of_monotonic,
+            )
+            for snapshot in snapshots
+        )
+        # Diagnostic schema v1 has no SQLite health DTO. Preserve the first-party
+        # backend's honest "custom" classification and surface exact durable counts
+        # in its existing structured issue channel until a schema revision exists.
+        issues.append(
+            DiagnosticIssue(
+                severity="info",
+                component="sqlite_backend",
+                message=(
+                    "durable rows: "
+                    f"acquire_markers={counts['acquire_markers']}, "
+                    f"refund_tombstones={counts['refund_tombstones']}"
+                ),
+                model_family=self._engine.model_family,
+            )
+        )
+        with self._diagnostic_lock:
+            waiters = tuple(
+                waiter_diagnostic_from_state(state, as_of_monotonic=as_of_monotonic)
+                for state in sorted(
+                    self._diagnostic_waiters.values(),
+                    key=lambda item: (item.wait_started_monotonic, item.waiter_id),
+                )
+            )
+        return BackendIntrospectionDiagnostic(
+            model_family=self._engine.model_family,
+            backend_type=backend_type_for_object(self),
+            as_of_monotonic=as_of_monotonic,
+            buckets=buckets,
+            waits=waiters,
+            memory_health=None,
+            redis_health=None,
+            issues=tuple(issues),
+        )
+
     def prepare_reconfigured_backend(
         self,
         new_backend: SyncRateLimiterBackend,
-        _cfg: PerModelConfig,
+        cfg: PerModelConfig,
     ) -> SyncRateLimiterBackend:
         if not isinstance(new_backend, SyncSqliteBackend):
             raise TypeError(
@@ -325,6 +401,25 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
             raise ValueError(
                 "SQLite reconfiguration requires the same db_path and key_prefix"
             )
+        old_ids = self._engine.bucket_ids
+        new_ids = new_backend._engine.bucket_ids  # noqa: SLF001
+        changed_ids = frozenset(
+            (quota.metric, int(quota.per_seconds))
+            for quota in cfg.quotas
+            if (quota.metric, int(quota.per_seconds)) in old_ids
+            and not math.isclose(
+                self._engine.configured_max_capacity(
+                    quota.metric, int(quota.per_seconds)
+                ),
+                float(quota.limit),
+                rel_tol=1e-12,
+                abs_tol=0.0,
+            )
+        )
+        self._engine.clear_max_capacity_overrides(
+            frozenset(old_ids - new_ids) | changed_ids,
+            current_time=time.time(),
+        )
         return new_backend
 
     def consume_capacity(
@@ -346,13 +441,35 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
         self._emit_consumed_callbacks(usage, result)
         return result.current_time
 
-    def wait_for_capacity(  # noqa: PLR0915
+    def wait_for_capacity(
         self,
         usage: FrozenUsage,
         *,
         timeout: float | None = None,
         reservation_id: str | None = None,
         reservation_lifetime_seconds: float | None = None,
+    ) -> float | None:
+        waiter_key = uuid.uuid4().hex
+        try:
+            return self._wait_for_capacity_impl(
+                usage,
+                timeout=timeout,
+                reservation_id=reservation_id,
+                reservation_lifetime_seconds=reservation_lifetime_seconds,
+                waiter_key=waiter_key,
+            )
+        finally:
+            with self._diagnostic_lock:
+                self._diagnostic_waiters.pop(waiter_key, None)
+
+    def _wait_for_capacity_impl(  # noqa: PLR0915
+        self,
+        usage: FrozenUsage,
+        *,
+        timeout: float | None,
+        reservation_id: str | None,
+        reservation_lifetime_seconds: float | None,
+        waiter_key: str,
     ) -> float | None:
         validate_backend_usage(usage, self._engine.metric_names)
         timeout = validate_timeout(timeout)
@@ -366,11 +483,14 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
 
         while True:
             try:
+                busy_timeout_ms, timeout_on_busy = self._wait_busy_timeout(deadline)
                 attempt = self._engine.try_consume(
                     usage,
                     current_time=time.time(),
                     reservation_id=reservation_id,
                     reservation_lifetime_seconds=reservation_lifetime_seconds,
+                    busy_timeout_ms=busy_timeout_ms,
+                    timeout_on_busy=timeout_on_busy,
                 )
             except BackendLockContentionError as exc:
                 if deadline is not None and time.monotonic() >= deadline:
@@ -389,6 +509,15 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
             result = attempt.result
             if attempt.available:
                 break
+            self._upsert_diagnostic_waiter(
+                waiter_key,
+                reservation_id=reservation_id,
+                usage=usage,
+                capacities=result.pre_capacities,
+                max_capacities=result.max_capacities,
+                deadline=deadline,
+                wait_started_at=wait_started_at,
+            )
             if deadline is not None and time.monotonic() >= deadline:
                 raise self._capacity_timeout_error(
                     usage,
@@ -474,6 +603,54 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
                 )
             raise
         return result.current_time
+
+    def _wait_busy_timeout(self, deadline: float | None) -> tuple[int, bool]:
+        if deadline is None:
+            return self._engine.busy_timeout_ms, False
+        remaining = max(0.0, deadline - time.monotonic())
+        timeout_ms = min(
+            self._engine.busy_timeout_ms,
+            max(0, math.ceil(remaining * 1000.0)),
+        )
+        return timeout_ms, timeout_ms == 0
+
+    def _upsert_diagnostic_waiter(  # noqa: PLR0913
+        self,
+        waiter_key: str,
+        *,
+        reservation_id: str | None,
+        usage: FrozenUsage,
+        capacities: Capacities,
+        max_capacities: Capacities,
+        deadline: float | None,
+        wait_started_at: float | None,
+    ) -> None:
+        limits = {
+            bucket_id: BackendBucketLimit(
+                effective_max_capacity=float(maximum),
+                refill_rate_per_second=float(maximum) / bucket_id[1],
+            )
+            for bucket_id, maximum in max_capacities.items()
+        }
+        state = DiagnosticWaiterState(
+            waiter_id=waiter_key,
+            reservation_id=reservation_id,
+            model_family=self._engine.model_family,
+            model=None,
+            request_id=None,
+            state="waiting_for_capacity",
+            usage=usage,
+            wait_started_monotonic=wait_started_at or time.monotonic(),
+            timeout_deadline_monotonic=deadline,
+            blocked_buckets=wait_bucket_diagnostics(
+                model_family=self._engine.model_family,
+                usage=usage,
+                capacities=dict(capacities),
+                limits=limits,
+            ),
+        )
+        with self._diagnostic_lock:
+            self._diagnostic_waiters[waiter_key] = state
 
     def refund_capacity(
         self,
@@ -568,6 +745,20 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
     ) -> None:
         value = _validate_max_capacity_finite_positive(value)
         self._engine.set_max_capacity(
+            metric,
+            per_seconds,
+            value,
+            current_time=time.time(),
+        )
+
+    def apply_configured_max_capacity(
+        self,
+        metric: str,
+        per_seconds: int,
+        value: float,
+    ) -> None:
+        value = _validate_max_capacity_finite_positive(value)
+        self._engine.apply_configured_max_capacity(
             metric,
             per_seconds,
             value,

--- a/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
@@ -201,11 +201,17 @@ class SyncSqliteBackendBuilder(SyncRateLimiterBackendBuilderInterface):
     ) -> float:
         if max_reservation_lifetime_seconds is None:
             return self._max_reservation_lifetime_seconds
-        return resolve_max_reservation_lifetime_seconds_from_ttls(
+        resolved = resolve_max_reservation_lifetime_seconds_from_ttls(
             max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
             bucket_ttl_seconds=self._bucket_ttl_seconds,
             refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
         )
+        if resolved > self._max_reservation_lifetime_seconds:
+            raise ValueError(
+                "max_reservation_lifetime_seconds exceeds the SQLite builder's "
+                "configured maximum"
+            )
+        return resolved
 
     def validate_reservation_lifetime_seconds(
         self,

--- a/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
@@ -278,7 +278,7 @@ class SyncSqliteBackendBuilder(SyncRateLimiterBackendBuilderInterface):
             prune_batch_size=self._prune_batch_size,
         )
         try:
-            engine.initialize_buckets(time.time())
+            engine.initialize_buckets()
         except BaseException:
             engine.close()
             raise
@@ -350,7 +350,7 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
     def introspect(self) -> BackendIntrospectionDiagnostic:
         as_of_monotonic = time.monotonic()
         issues: list[DiagnosticIssue] = []
-        snapshots, counts = self._engine.inspect_snapshot(current_time=time.time())
+        snapshots, counts = self._engine.inspect_snapshot()
         buckets = tuple(
             make_bucket_diagnostic(
                 model_family=self._engine.model_family,
@@ -433,7 +433,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
         )
         self._engine.clear_max_capacity_overrides(
             frozenset(old_ids - new_ids) | changed_ids,
-            current_time=time.time(),
         )
         self.close()
         return new_backend
@@ -460,7 +459,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
         usage = _normalize_usage(usage)
         result = self._engine.consume(
             usage,
-            current_time=time.time(),
             reservation_id=reservation_id,
             reservation_lifetime_seconds=reservation_lifetime_seconds,
         )
@@ -513,7 +511,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
                 busy_timeout_ms, timeout_on_busy = self._wait_busy_timeout(deadline)
                 attempt = self._engine.try_consume(
                     usage,
-                    current_time=time.time(),
                     reservation_id=reservation_id,
                     reservation_lifetime_seconds=reservation_lifetime_seconds,
                     busy_timeout_ms=busy_timeout_ms,
@@ -619,7 +616,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
                 self._engine.cleanup_consumption(
                     usage,
                     bucket_ids=consumed_bucket_ids,
-                    current_time=time.time(),
                     reservation_id=reservation_id,
                 )
             except BaseException as refund_exc:  # noqa: BLE001
@@ -749,7 +745,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
             reserved_usage,
             actual_usage,
             refund_bucket_ids=refund_bucket_ids,
-            current_time=time.time(),
             reservation_id=reservation_id,
             reservation_model_family=marker_model_family,
             reservation_bucket_ids=marker_bucket_ids,
@@ -780,7 +775,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
             metric,
             per_seconds,
             value,
-            current_time=time.time(),
         )
 
     def apply_configured_max_capacity(
@@ -794,7 +788,6 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
             metric,
             per_seconds,
             value,
-            current_time=time.time(),
         )
 
     def _compute_sleep(

--- a/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
@@ -1,0 +1,736 @@
+from __future__ import annotations
+
+import logging
+import math
+import os
+import random
+import threading
+import time
+import warnings
+from typing import TYPE_CHECKING, ClassVar
+
+from frozendict import frozendict
+
+from token_throttle._capacity import _validate_max_capacity_finite_positive
+from token_throttle._exceptions import BackendLockContentionError
+from token_throttle._interfaces._callbacks import (
+    BACKEND_CALLBACK_CRITICAL_EXCEPTIONS,
+    SyncRateLimiterCallbacks,
+    current_limiter_callback_context,
+    safe_invoke_sync_callback,
+)
+from token_throttle._interfaces._interfaces import (
+    PerModelConfig,
+    SyncRateLimiterBackend,
+    SyncRateLimiterBackendBuilderInterface,
+)
+from token_throttle._validation import (
+    _revalidate_dto,
+    _validate_key_prefix,
+    validate_backend_refund_usage_for_bucket_ids,
+    validate_backend_usage,
+    validate_sleep_interval,
+    validate_timeout,
+)
+
+from ._engine import (
+    DEFAULT_BUSY_TIMEOUT_MS,
+    DEFAULT_PRUNE_BATCH_SIZE,
+    BucketSpec,
+    CapacityResult,
+    SqliteEngine,
+)
+from ._ttl import (
+    DEFAULT_BUCKET_TTL_SECONDS,
+    DEFAULT_REFUND_DEDUP_TTL_SECONDS,
+    resolve_max_reservation_lifetime_seconds_from_ttls,
+    validate_bucket_ttl_covers_quota_windows,
+    validate_reservation_lifetime_ttl_invariant,
+    validate_sqlite_ttl_seconds,
+)
+
+if TYPE_CHECKING:
+    from token_throttle._interfaces._models import BucketId, Capacities, FrozenUsage
+
+_logger = logging.getLogger("token_throttle")
+_acquire_logger = logging.getLogger("token_throttle.acquire")
+_refund_logger = logging.getLogger("token_throttle.refund")
+
+
+def _validate_db_path(value: object) -> str:
+    if not isinstance(value, (str, os.PathLike)):
+        raise TypeError("db_path must be a str or os.PathLike[str]")
+    try:
+        path = os.fspath(value)
+    except TypeError as exc:
+        raise TypeError("db_path must be a str or os.PathLike[str]") from exc
+    if type(path) is not str:
+        raise TypeError("db_path must resolve to a str path")
+    if not path:
+        raise ValueError("db_path must not be empty")
+    if "\x00" in path:
+        raise ValueError("db_path must not contain NUL characters")
+    return os.path.realpath(path)
+
+
+def _validate_busy_timeout_ms(value: object) -> int:
+    if type(value) is not int:
+        raise TypeError("busy_timeout_ms must be an exact int number of milliseconds")
+    if value < 0:
+        raise ValueError("busy_timeout_ms must be greater than or equal to 0")
+    if value > 2**31 - 1:
+        raise ValueError(f"busy_timeout_ms must be <= {2**31 - 1}")
+    return value
+
+
+def _validate_prune_batch_size(value: object) -> int:
+    if type(value) is not int:
+        raise TypeError("prune_batch_size must be an exact int")
+    if value <= 0:
+        raise ValueError("prune_batch_size must be greater than 0")
+    return value
+
+
+def _normalize_usage(usage: FrozenUsage) -> FrozenUsage:
+    return frozendict({metric: float(amount) for metric, amount in usage.items()})
+
+
+def _require_marker_metadata(
+    *,
+    reservation_model_family: str | None,
+    reservation_bucket_ids: set[BucketId] | frozenset[BucketId] | None,
+    reservation_reserved_usage: FrozenUsage | None,
+) -> tuple[str, frozenset[BucketId], FrozenUsage]:
+    if (
+        reservation_model_family is None
+        or reservation_bucket_ids is None
+        or reservation_reserved_usage is None
+    ):
+        raise ValueError(
+            "reservation marker metadata is required for marker-authorized refunds"
+        )
+    return (
+        reservation_model_family,
+        frozenset(reservation_bucket_ids),
+        _normalize_usage(reservation_reserved_usage),
+    )
+
+
+def _validate_marker_refund_scope(
+    *,
+    reserved_usage: FrozenUsage,
+    refund_bucket_ids: frozenset[BucketId],
+    marker_bucket_ids: frozenset[BucketId],
+    marker_reserved_usage: FrozenUsage,
+) -> None:
+    if not refund_bucket_ids.issubset(marker_bucket_ids):
+        raise ValueError("refund bucket_ids do not match the acquire marker")
+    for metric in frozenset(metric for metric, _ in refund_bucket_ids):
+        if metric not in marker_reserved_usage:
+            raise ValueError("refund reserved_usage does not match the acquire marker")
+        if float(reserved_usage[metric]) != float(marker_reserved_usage[metric]):
+            raise ValueError("refund reserved_usage does not match the acquire marker")
+
+
+def _log_cancellation_refund_failure(
+    exc: BaseException,
+    *,
+    reservation_id: str | None,
+    usage: FrozenUsage,
+) -> None:
+    _refund_logger.warning(
+        "SQLite cancellation-path refund failed; reserved capacity for "
+        "reservation %s may not be returned until natural refill: %s: %s",
+        reservation_id,
+        type(exc).__name__,
+        exc,
+        exc_info=exc,
+        extra={
+            "token_throttle_reservation_id": reservation_id,
+            "token_throttle_usage": dict(usage),
+        },
+    )
+
+
+class SyncSqliteBackendBuilder(SyncRateLimiterBackendBuilderInterface):
+    """Build synchronous SQLite backends scoped by a database and key prefix."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        db_path: str | os.PathLike[str],
+        *,
+        key_prefix: str,
+        sleep_interval: float | None = None,
+        bucket_ttl_seconds: int = DEFAULT_BUCKET_TTL_SECONDS,
+        refund_dedup_ttl_seconds: int = DEFAULT_REFUND_DEDUP_TTL_SECONDS,
+        max_reservation_lifetime_seconds: float | None = None,
+        busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+        prune_batch_size: int = DEFAULT_PRUNE_BATCH_SIZE,
+    ) -> None:
+        super().__init__()
+        self._db_path = _validate_db_path(db_path)
+        self._key_prefix = _validate_key_prefix(key_prefix)
+        self._sleep_interval = validate_sleep_interval(sleep_interval)
+        self._bucket_ttl_seconds = validate_sqlite_ttl_seconds(
+            bucket_ttl_seconds,
+            name="bucket_ttl_seconds",
+        )
+        self._refund_dedup_ttl_seconds = validate_sqlite_ttl_seconds(
+            refund_dedup_ttl_seconds,
+            name="refund_dedup_ttl_seconds",
+        )
+        self._max_reservation_lifetime_seconds = (
+            resolve_max_reservation_lifetime_seconds_from_ttls(
+                max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
+                bucket_ttl_seconds=self._bucket_ttl_seconds,
+                refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+            )
+        )
+        self._busy_timeout_ms = _validate_busy_timeout_ms(busy_timeout_ms)
+        self._prune_batch_size = _validate_prune_batch_size(prune_batch_size)
+        self._engines: list[SqliteEngine] = []
+        self._lock = threading.Lock()
+
+    @property
+    def db_path(self) -> str:
+        return self._db_path
+
+    def resolve_max_reservation_lifetime_seconds(
+        self,
+        max_reservation_lifetime_seconds: float | None,
+    ) -> float:
+        if max_reservation_lifetime_seconds is None:
+            return self._max_reservation_lifetime_seconds
+        return resolve_max_reservation_lifetime_seconds_from_ttls(
+            max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
+            bucket_ttl_seconds=self._bucket_ttl_seconds,
+            refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+        )
+
+    def validate_reservation_lifetime_seconds(
+        self,
+        max_reservation_lifetime_seconds: float | None,
+    ) -> None:
+        validate_reservation_lifetime_ttl_invariant(
+            max_reservation_lifetime_seconds=max_reservation_lifetime_seconds,
+            bucket_ttl_seconds=self._bucket_ttl_seconds,
+            refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+        )
+
+    def build(
+        self,
+        cfg: PerModelConfig,
+        *,
+        callbacks: SyncRateLimiterCallbacks | None = None,
+    ) -> SyncSqliteBackend:
+        cfg = _revalidate_dto(cfg)
+        if callbacks is not None:
+            _revalidate_dto(callbacks)
+        validate_bucket_ttl_covers_quota_windows(
+            bucket_ttl_seconds=self._bucket_ttl_seconds,
+            quotas=cfg.quotas,
+        )
+        engine = SqliteEngine(
+            db_path=self._db_path,
+            key_prefix=self._key_prefix,
+            model_family=cfg.get_model_family(),
+            buckets=tuple(
+                BucketSpec(
+                    metric=quota.metric,
+                    per_seconds=int(quota.per_seconds),
+                    configured_max_capacity=float(quota.limit),
+                )
+                for quota in cfg.quotas
+            ),
+            bucket_ttl_seconds=self._bucket_ttl_seconds,
+            refund_dedup_ttl_seconds=self._refund_dedup_ttl_seconds,
+            max_reservation_lifetime_seconds=(self._max_reservation_lifetime_seconds),
+            busy_timeout_ms=self._busy_timeout_ms,
+            prune_batch_size=self._prune_batch_size,
+        )
+        try:
+            engine.initialize_buckets(time.time())
+        except BaseException:
+            engine.close()
+            raise
+        with self._lock:
+            self._engines.append(engine)
+        return SyncSqliteBackend(
+            engine=engine,
+            callbacks=callbacks,
+            limit_config=cfg,
+            sleep_interval=self._sleep_interval,
+        )
+
+    def close(self) -> None:
+        with self._lock:
+            engines = tuple(self._engines)
+            self._engines.clear()
+        for engine in engines:
+            engine.close()
+
+
+class SyncSqliteBackend(SyncRateLimiterBackend):
+    DEFAULT_SLEEP_INTERVAL: ClassVar[float] = 0.1
+    MAX_CROSS_WORKER_POLL: ClassVar[float] = 1.0
+    WAIT_JITTER_RATIO: ClassVar[float] = 0.2
+
+    def __init__(
+        self,
+        *,
+        engine: SqliteEngine,
+        limit_config: PerModelConfig,
+        sleep_interval: float | None = None,
+        callbacks: SyncRateLimiterCallbacks | None = None,
+    ) -> None:
+        super().__init__()
+        self._engine = engine
+        self._limit_config = _revalidate_dto(limit_config)
+        if callbacks is not None:
+            _revalidate_dto(callbacks)
+        self._callbacks = callbacks
+        validated_sleep = validate_sleep_interval(sleep_interval)
+        self._sleep_interval = (
+            self.DEFAULT_SLEEP_INTERVAL if validated_sleep is None else validated_sleep
+        )
+
+    def supports_metric_set_change(self) -> bool:
+        return True
+
+    def supports_durable_refund_dedup(self) -> bool:
+        return True
+
+    def supports_acquire_marker_authority(self) -> bool:
+        return True
+
+    def prepare_reconfigured_backend(
+        self,
+        new_backend: SyncRateLimiterBackend,
+        _cfg: PerModelConfig,
+    ) -> SyncRateLimiterBackend:
+        if not isinstance(new_backend, SyncSqliteBackend):
+            raise TypeError(
+                "SyncSqliteBackend can only reconfigure into another SyncSqliteBackend"
+            )
+        if (
+            self._engine.db_path != new_backend._engine.db_path  # noqa: SLF001
+            or self._engine.key_prefix != new_backend._engine.key_prefix  # noqa: SLF001
+        ):
+            raise ValueError(
+                "SQLite reconfiguration requires the same db_path and key_prefix"
+            )
+        return new_backend
+
+    def consume_capacity(
+        self,
+        usage: FrozenUsage,
+        *,
+        reservation_id: str | None = None,
+        reservation_lifetime_seconds: float | None = None,
+    ) -> float | None:
+        validate_backend_usage(usage, self._engine.metric_names)
+        usage = _normalize_usage(usage)
+        result = self._engine.consume(
+            usage,
+            current_time=time.time(),
+            reservation_id=reservation_id,
+            reservation_lifetime_seconds=reservation_lifetime_seconds,
+        )
+        self._warn_over_max_consumption(usage, result)
+        self._emit_consumed_callbacks(usage, result)
+        return result.current_time
+
+    def wait_for_capacity(  # noqa: PLR0915
+        self,
+        usage: FrozenUsage,
+        *,
+        timeout: float | None = None,
+        reservation_id: str | None = None,
+        reservation_lifetime_seconds: float | None = None,
+    ) -> float | None:
+        validate_backend_usage(usage, self._engine.metric_names)
+        timeout = validate_timeout(timeout)
+        usage = _normalize_usage(usage)
+        deadline = None if timeout is None else time.monotonic() + timeout
+        has_waited = False
+        wait_started_at: float | None = None
+        wait_start_callback_overhead = 0.0
+        first_failed_pre: Capacities = frozendict()
+        result: CapacityResult
+
+        while True:
+            try:
+                attempt = self._engine.try_consume(
+                    usage,
+                    current_time=time.time(),
+                    reservation_id=reservation_id,
+                    reservation_lifetime_seconds=reservation_lifetime_seconds,
+                )
+            except BackendLockContentionError as exc:
+                if deadline is not None and time.monotonic() >= deadline:
+                    raise TimeoutError(
+                        "Timed out waiting for SQLite write-lock contention"
+                    ) from exc
+                sleep_for = self._jittered_sleep(self._sleep_interval)
+                if deadline is not None:
+                    sleep_for = min(
+                        sleep_for,
+                        max(0.0, deadline - time.monotonic()),
+                    )
+                time.sleep(max(0.001, sleep_for))
+                continue
+
+            result = attempt.result
+            if attempt.available:
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                raise self._capacity_timeout_error(
+                    usage,
+                    result.pre_capacities,
+                    result.max_capacities,
+                )
+            if not has_waited:
+                has_waited = True
+                first_failed_pre = result.pre_capacities
+                wait_started_at = time.monotonic()
+                if self._callbacks and self._callbacks.on_wait_start:
+                    callback_started = time.monotonic()
+                    if deadline is not None and callback_started >= deadline:
+                        raise self._capacity_timeout_error(
+                            usage,
+                            first_failed_pre,
+                            result.max_capacities,
+                        )
+                    self._invoke_callback_safe(
+                        self._callbacks.on_wait_start,
+                        callback_slot="on_wait_start",
+                        model_family=self._limit_config.get_model_family(),
+                        preconsumption_capacities=first_failed_pre,
+                        usage=usage,
+                        **current_limiter_callback_context(),
+                    )
+                    wait_start_callback_overhead += time.monotonic() - callback_started
+                    if deadline is not None and time.monotonic() >= deadline:
+                        raise self._capacity_timeout_error(
+                            usage,
+                            first_failed_pre,
+                            result.max_capacities,
+                        )
+            computed = self._compute_sleep(
+                usage,
+                result.pre_capacities,
+                result.max_capacities,
+            )
+            effective = self._jittered_sleep(min(computed, self.MAX_CROSS_WORKER_POLL))
+            effective = min(effective, self.MAX_CROSS_WORKER_POLL)
+            if deadline is not None:
+                effective = min(effective, max(0.0, deadline - time.monotonic()))
+            time.sleep(max(0.001, effective))
+
+        consumed_monotonic = time.monotonic()
+        consumed_bucket_ids = self._engine.bucket_ids
+        try:
+            self._emit_consumed_callbacks(usage, result)
+            if (
+                has_waited
+                and self._callbacks
+                and self._callbacks.after_wait_end_consumption
+            ):
+                wait_time_s = max(
+                    0.0,
+                    consumed_monotonic
+                    - (wait_started_at or consumed_monotonic)
+                    - wait_start_callback_overhead,
+                )
+                self._invoke_callback_safe(
+                    self._callbacks.after_wait_end_consumption,
+                    callback_slot="after_wait_end_consumption",
+                    model_family=self._limit_config.get_model_family(),
+                    preconsumption_capacities=result.pre_capacities,
+                    postconsumption_capacities=result.post_capacities,
+                    usage=usage,
+                    wait_time_s=wait_time_s,
+                    **current_limiter_callback_context(),
+                )
+        except BaseException:
+            try:
+                self._engine.cleanup_consumption(
+                    usage,
+                    bucket_ids=consumed_bucket_ids,
+                    current_time=time.time(),
+                    reservation_id=reservation_id,
+                )
+            except BaseException as refund_exc:  # noqa: BLE001
+                _log_cancellation_refund_failure(
+                    refund_exc,
+                    reservation_id=reservation_id,
+                    usage=usage,
+                )
+            raise
+        return result.current_time
+
+    def refund_capacity(
+        self,
+        reserved_usage: FrozenUsage,
+        actual_usage: FrozenUsage,
+    ) -> None:
+        self.refund_capacity_for_buckets(
+            reserved_usage,
+            actual_usage,
+            bucket_ids=self._engine.bucket_ids,
+        )
+
+    def refund_capacity_for_buckets(  # noqa: PLR0913
+        self,
+        reserved_usage: FrozenUsage,
+        actual_usage: FrozenUsage,
+        *,
+        bucket_ids: set[BucketId] | frozenset[BucketId] | None = None,
+        reservation_id: str | None = None,
+        reservation_model_family: str | None = None,
+        reservation_bucket_ids: set[BucketId] | frozenset[BucketId] | None = None,
+        reservation_reserved_usage: FrozenUsage | None = None,
+    ) -> bool:
+        backend_bucket_ids = self._engine.bucket_ids
+        refund_bucket_ids = (
+            backend_bucket_ids if bucket_ids is None else frozenset(bucket_ids)
+        )
+        validate_backend_refund_usage_for_bucket_ids(
+            reserved_usage,
+            actual_usage,
+            refund_bucket_ids,
+            backend_bucket_ids,
+        )
+        reserved_usage = _normalize_usage(reserved_usage)
+        actual_usage = _normalize_usage(actual_usage)
+        marker_model_family: str | None = None
+        marker_bucket_ids: frozenset[BucketId] | None = None
+        marker_reserved_usage: FrozenUsage | None = None
+        if reservation_id is not None:
+            (
+                marker_model_family,
+                marker_bucket_ids,
+                marker_reserved_usage,
+            ) = _require_marker_metadata(
+                reservation_model_family=reservation_model_family,
+                reservation_bucket_ids=reservation_bucket_ids,
+                reservation_reserved_usage=reservation_reserved_usage,
+            )
+            _validate_marker_refund_scope(
+                reserved_usage=reserved_usage,
+                refund_bucket_ids=refund_bucket_ids,
+                marker_bucket_ids=marker_bucket_ids,
+                marker_reserved_usage=marker_reserved_usage,
+            )
+        if not refund_bucket_ids and reservation_id is None:
+            return True
+        self._warn_refund_overuse(
+            reserved_usage,
+            actual_usage,
+            refund_bucket_ids,
+            reservation_id=reservation_id,
+        )
+        result = self._engine.refund(
+            reserved_usage,
+            actual_usage,
+            refund_bucket_ids=refund_bucket_ids,
+            current_time=time.time(),
+            reservation_id=reservation_id,
+            reservation_model_family=marker_model_family,
+            reservation_bucket_ids=marker_bucket_ids,
+            reservation_reserved_usage=marker_reserved_usage,
+        )
+        self._fresh_start_buckets_callback(result.fresh_bucket_ids)
+        if self._callbacks and self._callbacks.on_capacity_refunded:
+            self._invoke_callback_safe(
+                self._callbacks.on_capacity_refunded,
+                callback_slot="on_capacity_refunded",
+                model_family=self._limit_config.get_model_family(),
+                reserved_usage=reserved_usage,
+                actual_usage=actual_usage,
+                refunded_usage=result.refunded_usage,
+                prerefund_capacities=result.pre_capacities,
+                postrefund_capacities=result.post_capacities,
+            )
+        return True
+
+    def set_max_capacity(
+        self,
+        metric: str,
+        per_seconds: int,
+        value: float,
+    ) -> None:
+        value = _validate_max_capacity_finite_positive(value)
+        self._engine.set_max_capacity(
+            metric,
+            per_seconds,
+            value,
+            current_time=time.time(),
+        )
+
+    def _compute_sleep(
+        self,
+        usage: FrozenUsage,
+        capacities: Capacities,
+        max_capacities: Capacities,
+    ) -> float:
+        max_wait = 0.0
+        for (metric, per_seconds), current_capacity in capacities.items():
+            deficit = float(usage.get(metric, 0.0)) - float(current_capacity)
+            if deficit <= 0:
+                continue
+            max_capacity = float(max_capacities[(metric, per_seconds)])
+            rate_per_sec = max_capacity / float(per_seconds)
+            if not math.isfinite(rate_per_sec) or rate_per_sec <= 0:
+                raise ValueError(
+                    "Bucket rate is non-positive/non-finite — likely a "
+                    "misconfigured max_capacity"
+                )
+            max_wait = max(max_wait, deficit / rate_per_sec)
+        return max_wait if max_wait > 0 else self._sleep_interval
+
+    def _jittered_sleep(self, value: float) -> float:
+        return value * random.uniform(  # noqa: S311 - scheduling jitter, not security.
+            1.0 - self.WAIT_JITTER_RATIO,
+            1.0 + self.WAIT_JITTER_RATIO,
+        )
+
+    def _capacity_timeout_error(
+        self,
+        usage: FrozenUsage,
+        capacities: Capacities,
+        max_capacities: Capacities,
+    ) -> TimeoutError:
+        bottleneck_id: BucketId | None = None
+        available: float | None = None
+        requested: float | None = None
+        largest_deficit = 0.0
+        for bucket_id, capacity in capacities.items():
+            metric, _ = bucket_id
+            deficit = float(usage.get(metric, 0.0)) - float(capacity)
+            if deficit > largest_deficit:
+                largest_deficit = deficit
+                bottleneck_id = bucket_id
+                available = float(capacity)
+                requested = float(usage[metric])
+        computed_sleep = self._compute_sleep(usage, capacities, max_capacities)
+        return TimeoutError(
+            "Timed out waiting for capacity "
+            f"(bottleneck={bottleneck_id}, available={available}, "
+            f"requested={requested}, computed_sleep={computed_sleep})"
+        )
+
+    def _warn_over_max_consumption(
+        self,
+        usage: FrozenUsage,
+        result: CapacityResult,
+    ) -> None:
+        for metric, amount in usage.items():
+            matching = [
+                (bucket_id, maximum)
+                for bucket_id, maximum in result.max_capacities.items()
+                if bucket_id[0] == metric and amount > maximum
+            ]
+            for bucket_id, maximum in matching:
+                message = (
+                    f"record_usage value for {metric} ({amount}) exceeds bucket "
+                    f"max capacity ({maximum}). Capacity will go deeply negative."
+                )
+                warnings.warn(message, RuntimeWarning, stacklevel=3)
+                _acquire_logger.warning(
+                    message,
+                    extra={
+                        "token_throttle_metric": metric,
+                        "token_throttle_model_family": (
+                            self._limit_config.get_model_family()
+                        ),
+                        "token_throttle_value": amount,
+                        "token_throttle_bucket_id": bucket_id,
+                    },
+                )
+
+    def _warn_refund_overuse(
+        self,
+        reserved_usage: FrozenUsage,
+        actual_usage: FrozenUsage,
+        refund_bucket_ids: frozenset[BucketId],
+        *,
+        reservation_id: str | None,
+    ) -> None:
+        for metric, reserved_amount in reserved_usage.items():
+            actual_amount = actual_usage[metric]
+            refund_amount = float(reserved_amount) - float(actual_amount)
+            if refund_amount >= 0:
+                continue
+            message = (
+                f"Actual usage ({actual_amount}) for {metric} exceeds reserved "
+                f"usage ({reserved_amount}). Applying negative refund."
+            )
+            warnings.warn(message, RuntimeWarning, stacklevel=3)
+            _refund_logger.warning(
+                message,
+                extra={
+                    "token_throttle_metric": metric,
+                    "token_throttle_model_family": (
+                        self._limit_config.get_model_family()
+                    ),
+                    "token_throttle_value": refund_amount,
+                    "token_throttle_bucket_ids": sorted(
+                        bucket_id
+                        for bucket_id in refund_bucket_ids
+                        if bucket_id[0] == metric
+                    ),
+                    "token_throttle_reservation_id": reservation_id,
+                },
+            )
+
+    def _emit_consumed_callbacks(
+        self,
+        usage: FrozenUsage,
+        result: CapacityResult,
+    ) -> None:
+        self._fresh_start_buckets_callback(result.fresh_bucket_ids)
+        if self._callbacks and self._callbacks.on_capacity_consumed:
+            self._invoke_callback_safe(
+                self._callbacks.on_capacity_consumed,
+                callback_slot="on_capacity_consumed",
+                model_family=self._limit_config.get_model_family(),
+                preconsumption_capacities=result.pre_capacities,
+                postconsumption_capacities=result.post_capacities,
+                usage=usage,
+                current_time=result.current_time,
+            )
+
+    def _fresh_start_buckets_callback(
+        self,
+        bucket_ids: tuple[BucketId, ...],
+    ) -> None:
+        if not (
+            bucket_ids
+            and self._callbacks
+            and self._callbacks.on_missing_consumption_data
+        ):
+            return
+        for metric, per_seconds in bucket_ids:
+            self._invoke_callback_safe(
+                self._callbacks.on_missing_consumption_data,
+                callback_slot="on_missing_consumption_data",
+                model_family=self._limit_config.get_model_family(),
+                usage_metric=metric,
+                per_seconds=per_seconds,
+            )
+
+    @staticmethod
+    def _invoke_callback_safe(
+        callback,
+        *,
+        callback_slot: str = "callback",
+        **kwargs,
+    ) -> None:
+        safe_invoke_sync_callback(
+            callback,
+            critical=BACKEND_CALLBACK_CRITICAL_EXCEPTIONS,
+            log_label="Rate limiter callback",
+            callback_slot=callback_slot,
+            **kwargs,
+        )

--- a/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
@@ -61,6 +61,8 @@ from ._ttl import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from token_throttle._interfaces._models import BucketId, Capacities, FrozenUsage
 
 _logger = logging.getLogger("token_throttle")
@@ -282,12 +284,21 @@ class SyncSqliteBackendBuilder(SyncRateLimiterBackendBuilderInterface):
             raise
         with self._lock:
             self._engines.append(engine)
+
+        def deregister_engine() -> None:
+            self._discard_engine(engine)
+
         return SyncSqliteBackend(
             engine=engine,
             callbacks=callbacks,
             limit_config=cfg,
             sleep_interval=self._sleep_interval,
+            on_close=deregister_engine,
         )
+
+    def _discard_engine(self, engine: SqliteEngine) -> None:
+        with self._lock:
+            self._engines = [item for item in self._engines if item is not engine]
 
     def close(self) -> None:
         with self._lock:
@@ -309,6 +320,7 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
         limit_config: PerModelConfig,
         sleep_interval: float | None = None,
         callbacks: SyncRateLimiterCallbacks | None = None,
+        on_close: Callable[[], None] | None = None,
     ) -> None:
         super().__init__()
         self._engine = engine
@@ -318,6 +330,9 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
         self._callbacks = callbacks
         self._diagnostic_waiters: dict[str, DiagnosticWaiterState] = {}
         self._diagnostic_lock = threading.Lock()
+        self._close_lock = threading.Lock()
+        self._closed = False
+        self._on_close = on_close
         validated_sleep = validate_sleep_interval(sleep_interval)
         self._sleep_interval = (
             self.DEFAULT_SLEEP_INTERVAL if validated_sleep is None else validated_sleep
@@ -420,7 +435,19 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
             frozenset(old_ids - new_ids) | changed_ids,
             current_time=time.time(),
         )
+        self.close()
         return new_backend
+
+    def close(self) -> None:
+        with self._close_lock:
+            if self._closed:
+                return
+            self._closed = True
+        try:
+            self._engine.close()
+        finally:
+            if self._on_close is not None:
+                self._on_close()
 
     def consume_capacity(
         self,

--- a/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
@@ -632,25 +632,30 @@ class SyncSqliteBackend(SyncRateLimiterBackend):
             )
             for bucket_id, maximum in max_capacities.items()
         }
-        state = DiagnosticWaiterState(
-            waiter_id=waiter_key,
-            reservation_id=reservation_id,
-            model_family=self._engine.model_family,
-            model=None,
-            request_id=None,
-            state="waiting_for_capacity",
-            usage=usage,
-            wait_started_monotonic=wait_started_at or time.monotonic(),
-            timeout_deadline_monotonic=deadline,
-            blocked_buckets=wait_bucket_diagnostics(
-                model_family=self._engine.model_family,
-                usage=usage,
-                capacities=dict(capacities),
-                limits=limits,
-            ),
-        )
         with self._diagnostic_lock:
-            self._diagnostic_waiters[waiter_key] = state
+            previous = self._diagnostic_waiters.get(waiter_key)
+            started = (
+                previous.wait_started_monotonic
+                if previous is not None
+                else wait_started_at or time.monotonic()
+            )
+            self._diagnostic_waiters[waiter_key] = DiagnosticWaiterState(
+                waiter_id=waiter_key,
+                reservation_id=reservation_id,
+                model_family=self._engine.model_family,
+                model=None,
+                request_id=None,
+                state="waiting_for_capacity",
+                usage=usage,
+                wait_started_monotonic=started,
+                timeout_deadline_monotonic=deadline,
+                blocked_buckets=wait_bucket_diagnostics(
+                    model_family=self._engine.model_family,
+                    usage=usage,
+                    capacities=dict(capacities),
+                    limits=limits,
+                ),
+            )
 
     def refund_capacity(
         self,

--- a/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_sqlite/_sync_backend.py
@@ -83,6 +83,12 @@ def _validate_db_path(value: object) -> str:
         raise ValueError("db_path must not be empty")
     if "\x00" in path:
         raise ValueError("db_path must not contain NUL characters")
+    if path == ":memory:" or path.startswith("file:"):
+        raise ValueError(
+            "db_path must be a filesystem path; SQLite in-memory databases and "
+            "file: URIs do not provide the backend's required cross-process "
+            "sharing semantics"
+        )
     return os.path.realpath(path)
 
 

--- a/token_throttle/_limiter_backends/_sqlite/_ttl.py
+++ b/token_throttle/_limiter_backends/_sqlite/_ttl.py
@@ -64,6 +64,17 @@ def derive_default_max_reservation_lifetime_seconds_from_ttls(
     refund_dedup_ttl_seconds: int,
     safety_margin: float = RESERVATION_LIFETIME_TTL_SAFETY_MARGIN,
 ) -> float:
+    """
+    Derive the largest default that still satisfies the strict TTL invariant.
+
+    SQLite bucket state, acquire markers, and refund tombstones must all
+    outlive the reservation refund window. The public rule of thumb is the
+    smaller TTL divided by the safety margin (2 by default), but equality at
+    that quotient is invalid because the invariant is strict: each TTL must be
+    greater than ``lifetime * safety_margin``. ``nextafter`` selects the
+    immediately smaller representable float so the derived default cannot
+    reject itself at that boundary.
+    """
     margin = _validate_safety_margin(safety_margin)
     bucket_ttl = validate_sqlite_ttl_seconds(
         bucket_ttl_seconds,
@@ -83,6 +94,7 @@ def resolve_max_reservation_lifetime_seconds_from_ttls(
     refund_dedup_ttl_seconds: int,
     safety_margin: float = RESERVATION_LIFETIME_TTL_SAFETY_MARGIN,
 ) -> float:
+    """Resolve an explicit lifetime or derive one under the strict TTL rule."""
     max_lifetime = validate_max_reservation_lifetime_seconds(
         max_reservation_lifetime_seconds
     )

--- a/token_throttle/_limiter_backends/_sqlite/_ttl.py
+++ b/token_throttle/_limiter_backends/_sqlite/_ttl.py
@@ -1,0 +1,158 @@
+import math
+from collections.abc import Iterable
+
+from token_throttle._interfaces._models import Quota
+
+DEFAULT_BUCKET_TTL_SECONDS = 7 * 24 * 60 * 60
+DEFAULT_REFUND_DEDUP_TTL_SECONDS = 7 * 24 * 60 * 60
+RESERVATION_LIFETIME_TTL_SAFETY_MARGIN = 2.0
+MAX_SQLITE_TTL_SECONDS = 2**31 - 1
+
+
+def validate_sqlite_ttl_seconds(value: object, *, name: str) -> int:
+    if type(value) is not int:
+        raise TypeError(
+            f"{name} must be an exact int number of seconds "
+            f"(got {type(value).__name__}); use a plain int such as 604800"
+        )
+    if value <= 0:
+        raise ValueError(f"{name} must be greater than 0 (got {value!r})")
+    if value > MAX_SQLITE_TTL_SECONDS:
+        raise ValueError(
+            f"{name} must be <= {MAX_SQLITE_TTL_SECONDS} seconds "
+            f"(got {value!r}); choose a smaller SQLite TTL"
+        )
+    return value
+
+
+def validate_max_reservation_lifetime_seconds(value: object) -> float | None:
+    if value is None:
+        return None
+    if type(value) is bool or not isinstance(value, (int, float)):
+        raise ValueError(
+            "max_reservation_lifetime_seconds must be finite and greater than 0"
+        )
+    value_float = float(value)
+    if not math.isfinite(value_float) or value_float <= 0:
+        raise ValueError(
+            "max_reservation_lifetime_seconds must be finite and greater than 0"
+        )
+    if value_float > MAX_SQLITE_TTL_SECONDS:
+        raise ValueError(
+            "max_reservation_lifetime_seconds must be <= "
+            f"{MAX_SQLITE_TTL_SECONDS} seconds (got {value!r})"
+        )
+    return value_float
+
+
+def _validate_safety_margin(value: object) -> float:
+    if (
+        type(value) is bool
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or float(value) <= 1.0
+    ):
+        raise ValueError(
+            "reservation lifetime TTL safety_margin must be greater than 1"
+        )
+    return float(value)
+
+
+def derive_default_max_reservation_lifetime_seconds_from_ttls(
+    *,
+    bucket_ttl_seconds: int,
+    refund_dedup_ttl_seconds: int,
+    safety_margin: float = RESERVATION_LIFETIME_TTL_SAFETY_MARGIN,
+) -> float:
+    margin = _validate_safety_margin(safety_margin)
+    bucket_ttl = validate_sqlite_ttl_seconds(
+        bucket_ttl_seconds,
+        name="bucket_ttl_seconds",
+    )
+    refund_ttl = validate_sqlite_ttl_seconds(
+        refund_dedup_ttl_seconds,
+        name="refund_dedup_ttl_seconds",
+    )
+    return math.nextafter(float(min(bucket_ttl, refund_ttl)) / margin, 0.0)
+
+
+def resolve_max_reservation_lifetime_seconds_from_ttls(
+    *,
+    max_reservation_lifetime_seconds: float | None,
+    bucket_ttl_seconds: int,
+    refund_dedup_ttl_seconds: int,
+    safety_margin: float = RESERVATION_LIFETIME_TTL_SAFETY_MARGIN,
+) -> float:
+    max_lifetime = validate_max_reservation_lifetime_seconds(
+        max_reservation_lifetime_seconds
+    )
+    if max_lifetime is None:
+        return derive_default_max_reservation_lifetime_seconds_from_ttls(
+            bucket_ttl_seconds=bucket_ttl_seconds,
+            refund_dedup_ttl_seconds=refund_dedup_ttl_seconds,
+            safety_margin=safety_margin,
+        )
+    validate_reservation_lifetime_ttl_invariant(
+        max_reservation_lifetime_seconds=max_lifetime,
+        bucket_ttl_seconds=bucket_ttl_seconds,
+        refund_dedup_ttl_seconds=refund_dedup_ttl_seconds,
+        safety_margin=safety_margin,
+    )
+    return max_lifetime
+
+
+def validate_reservation_lifetime_ttl_invariant(
+    *,
+    max_reservation_lifetime_seconds: float | None,
+    bucket_ttl_seconds: int,
+    refund_dedup_ttl_seconds: int,
+    safety_margin: float = RESERVATION_LIFETIME_TTL_SAFETY_MARGIN,
+) -> None:
+    max_lifetime = validate_max_reservation_lifetime_seconds(
+        max_reservation_lifetime_seconds
+    )
+    if max_lifetime is None:
+        return
+    margin = _validate_safety_margin(safety_margin)
+    ttl_by_name = {
+        "bucket_ttl_seconds": validate_sqlite_ttl_seconds(
+            bucket_ttl_seconds,
+            name="bucket_ttl_seconds",
+        ),
+        "refund_dedup_ttl_seconds": validate_sqlite_ttl_seconds(
+            refund_dedup_ttl_seconds,
+            name="refund_dedup_ttl_seconds",
+        ),
+    }
+    required_ttl = max_lifetime * margin
+    too_short = [
+        f"{name}={ttl}"
+        for name, ttl in ttl_by_name.items()
+        if float(ttl) <= required_ttl
+    ]
+    if too_short:
+        raise ValueError(
+            "SQLite TTLs must exceed max_reservation_lifetime_seconds * "
+            f"{margin:g}; required > {required_ttl:g}s, got "
+            f"{', '.join(too_short)}"
+        )
+
+
+def validate_bucket_ttl_covers_quota_windows(
+    *,
+    bucket_ttl_seconds: int,
+    quotas: Iterable[Quota],
+) -> None:
+    too_long = [
+        f"{quota.metric}: per_seconds={quota.per_seconds}"
+        for quota in quotas
+        if quota.per_seconds > bucket_ttl_seconds
+    ]
+    if too_long:
+        raise ValueError(
+            "bucket_ttl_seconds must be >= every configured quota's "
+            f"per_seconds (got bucket_ttl_seconds={bucket_ttl_seconds}); "
+            f"offending quotas: {', '.join(too_long)}. Raise "
+            "bucket_ttl_seconds to at least the longest quota window, or "
+            "shorten that quota's per_seconds."
+        )

--- a/token_throttle/_limiter_backends/_sqlite/_ttl.py
+++ b/token_throttle/_limiter_backends/_sqlite/_ttl.py
@@ -155,6 +155,16 @@ def validate_bucket_ttl_covers_quota_windows(
     bucket_ttl_seconds: int,
     quotas: Iterable[Quota],
 ) -> None:
+    """
+    Fail fast when a quota window outlives the bucket state TTL.
+
+    SQLite prunes idle bucket rows after ``bucket_ttl_seconds``. If a quota's
+    ``per_seconds`` window is longer than that, an idle gap between the TTL and
+    window silently removes the bucket state, and the next read re-grants full
+    capacity instead of preserving the drained long-window state. Equality
+    (``per_seconds == bucket_ttl_seconds``) is allowed: the bucket only needs to
+    survive gaps *shorter* than the window itself.
+    """
     too_long = [
         f"{quota.metric}: per_seconds={quota.per_seconds}"
         for quota in quotas

--- a/token_throttle/_rate_limiter.py
+++ b/token_throttle/_rate_limiter.py
@@ -131,6 +131,8 @@ def _backend_type_name(backend: object) -> str:
     backend_module = type(backend).__module__
     if "._redis." in backend_module:
         return "redis"
+    if "._sqlite." in backend_module:
+        return "sqlite"
     if "._memory." in backend_module:
         return "memory"
     return "custom"
@@ -804,9 +806,9 @@ class RateLimiter(BaseRateLimiter):
         """
         Return a redacted point-in-time limiter health snapshot.
 
-        The snapshot intentionally omits backend connection strings and Redis
-        key prefixes. Redis marker/refund counts are local best-effort
-        estimates derived from limiter bookkeeping, not a cross-process SCAN.
+        The snapshot intentionally omits backend connection strings and key
+        prefixes. Durable marker/refund counts are local best-effort estimates
+        derived from limiter bookkeeping, not a cross-process datastore scan.
         """
         in_flight_reservations = len(
             self._in_flight_reservation_ids | self._pending_acquire_reservations
@@ -816,7 +818,7 @@ class RateLimiter(BaseRateLimiter):
             "model_families": len(self._model_family_to_backend),
             "backend_type": _backend_type_name(self._backend),
         }
-        if state["backend_type"] == "redis":
+        if state["backend_type"] in {"redis", "sqlite"}:
             state["marker_count_estimate"] = in_flight_reservations
             state["refund_dedup_count_estimate"] = sum(
                 1

--- a/token_throttle/_sync_rate_limiter.py
+++ b/token_throttle/_sync_rate_limiter.py
@@ -131,6 +131,8 @@ def _backend_type_name(backend: object) -> str:
     backend_module = type(backend).__module__
     if "._redis." in backend_module:
         return "redis"
+    if "._sqlite." in backend_module:
+        return "sqlite"
     if "._memory." in backend_module:
         return "memory"
     return "custom"
@@ -763,9 +765,9 @@ class SyncRateLimiter:
         """
         Return a redacted point-in-time limiter health snapshot.
 
-        The snapshot intentionally omits backend connection strings and Redis
-        key prefixes. Redis marker/refund counts are local best-effort
-        estimates derived from limiter bookkeeping, not a cross-process SCAN.
+        The snapshot intentionally omits backend connection strings and key
+        prefixes. Durable marker/refund counts are local best-effort estimates
+        derived from limiter bookkeeping, not a cross-process datastore scan.
         """
         in_flight_reservations = len(
             self._in_flight_reservation_ids | self._pending_acquire_reservations
@@ -775,7 +777,7 @@ class SyncRateLimiter:
             "model_families": len(self._model_family_to_backend),
             "backend_type": _backend_type_name(self._backend),
         }
-        if state["backend_type"] == "redis":
+        if state["backend_type"] in {"redis", "sqlite"}:
             state["marker_count_estimate"] = in_flight_reservations
             state["refund_dedup_count_estimate"] = sum(
                 1

--- a/token_throttle/conformance.py
+++ b/token_throttle/conformance.py
@@ -1040,6 +1040,26 @@ class _AsyncRefundFailureBuilder(RateLimiterBackendBuilderInterface):
     def __getattr__(self, name: str) -> object:
         return getattr(self._builder, name)
 
+    def resolve_max_reservation_lifetime_seconds(
+        self,
+        value: float | None,
+    ) -> float | None:
+        resolver = getattr(
+            self._builder,
+            "resolve_max_reservation_lifetime_seconds",
+            None,
+        )
+        return resolver(value) if callable(resolver) else value
+
+    def validate_reservation_lifetime_seconds(self, value: float | None) -> None:
+        validator = getattr(
+            self._builder,
+            "validate_reservation_lifetime_seconds",
+            None,
+        )
+        if callable(validator):
+            validator(value)
+
     async def aclose(self) -> None:
         await self._builder.aclose()
 
@@ -1186,6 +1206,26 @@ class _SyncRefundFailureBuilder(SyncRateLimiterBackendBuilderInterface):
 
     def __getattr__(self, name: str) -> object:
         return getattr(self._builder, name)
+
+    def resolve_max_reservation_lifetime_seconds(
+        self,
+        value: float | None,
+    ) -> float | None:
+        resolver = getattr(
+            self._builder,
+            "resolve_max_reservation_lifetime_seconds",
+            None,
+        )
+        return resolver(value) if callable(resolver) else value
+
+    def validate_reservation_lifetime_seconds(self, value: float | None) -> None:
+        validator = getattr(
+            self._builder,
+            "validate_reservation_lifetime_seconds",
+            None,
+        )
+        if callable(validator):
+            validator(value)
 
     def close(self) -> None:
         self._builder.close()


### PR DESCRIPTION
## What

Adds stdlib-only **SQLite backends** (`SyncSqliteBackend` / `SqliteBackend` with their builders) that give cross-process rate limiting on a single host with **no running service** — filling the gap between the per-process memory backend and the server-requiring Redis backend:

| Deployment shape | Backend |
|---|---|
| Single process | memory (SQLite/Redis also work; SQLite adds persistence across restarts) |
| Multiple processes, one host, no server | **SQLite (new)** |
| Multiple machines | Redis |

## Highlights

- **Full backend contract**: acquire-marker authority, durable refund dedup, and metric-set change all claimed and enforced; passes the complete sync + async conformance harness.
- **Transactional core**: WAL + `BEGIN IMMEDIATE`; multi-bucket consumption, acquire markers, and refund tombstones commit atomically. Per-row absolute TTL expiry; bounded lazy pruning, no daemon.
- **Two-layer limits** matching the documented Redis contract: configured limits stay process-local; runtime overrides persist with a TTL and are cleared by config updates.
- **Clock discipline for a persistent store**: timestamps sampled under the write lock; poisoned future timestamps self-heal transactionally.
- **Prompt try-acquire under contention**: per-operation busy timeouts keep `timeout=0` at sub-millisecond returns even while another process holds the write lock (verified by a multi-process regression test; pre-fix behavior blocked ~5s).
- **First-class diagnostics**: `backend_type="sqlite"`, structured health DTO with marker/tombstone counts, read-only `introspect()`, `snapshot_state()` durable estimates.
- **New multi-process test suite** (`tests/multiprocess`): real spawned interpreters covering shared-budget enforcement, cross-process refund wake-up, SIGKILL orphan recovery via linear refill with fail-closed late refunds, contention accounting, fresh-interpreter persistence, and try-acquire promptness — parametrized over Redis and SQLite, with the memory backend as the documented expected-failure control.
- **Docs**: new `docs/sqlite-backend.md` (scope boundary incl. no network filesystems, clock authority, TTL knobs, crash semantics, performance envelope), README backend selector, backend-generic contention docs, CHANGELOG.
- Async cancellation paths hardened and pinned by dedicated tests (commit-then-cancel, cancel-during-cleanup, repeated hostile cancels, cancel-during-refund with duplicate-refund refusal on retry).

## Scope boundary (documented)

Single host, local filesystem only. Not for NFS/SMB/overlay mounts, not cross-machine (that remains Redis), not a high-RPS backend.

## Release notes

Additive: new public exports plus one additive widening of the diagnostics backend-type literal. Intended release: **minor** (10.1.0; CHANGELOG section dated accordingly).

Local gates before this PR: 2,341 passed / 6 skipped / 1 intentional xfail across unit, conformance, lint, multiprocess, and integration suites against a dedicated Redis DB; ruff check + format clean; mypy clean. Windows-runner and Linux-container behavior are exactly what this PR's CI matrix exists to prove.