### PR TITLE
Support redis-py 8 and stop capping the client range at the next major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,34 @@ jobs:
 
   test-min-deps:
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
-      - run: uv sync --group dev --resolution lowest-direct
-      - run: uv run pytest tests/unit -v
+      # Select only the Redis extra: --all-extras would also put the unrelated
+      # tiktoken integration on its floor and make failures harder to attribute.
+      - run: uv sync --extra redis --group dev --resolution lowest-direct
+      # The explicit assertion makes the declared floor auditable. --no-sync is
+      # required because plain `uv run` would resolve the lowest-direct lock back
+      # to the default highest resolution before running anything.
+      - run: uv run --no-sync python -c "import redis; assert redis.__version__ == '5.2.1', redis.__version__; print(f'redis-py {redis.__version__}')"
+      - run: uv run --no-sync pytest tests/unit -v --redis-url redis://localhost:6379/13
+      # Exercise only Redis cases here; the integration matrix already covers
+      # every backend, and duplicating its memory/SQLite cases would slow PRs.
+      - run: uv run --no-sync pytest tests/integration tests/multiprocess -m redis -v --redis-url redis://localhost:6379/13
+        env:
+          TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE: "2"
 
   # First-class gate for the AST/structural-prevention layer. The unit tiers
   # run `pytest tests/unit`, an explicit path that excludes tests/conformance/;

--- a/.github/workflows/redis-client-drift.yml
+++ b/.github/workflows/redis-client-drift.yml
@@ -1,0 +1,47 @@
+name: Redis Client Drift Canary
+
+# Runs the Redis-backed integration and multiprocess suites, plus the package
+# type check, against the LATEST unpinned redis-py release rather than the
+# version pinned in uv.lock. The redis extra is deliberately uncapped, so this
+# provides a loud weekly signal when a new client release (including a future
+# major) breaks runtime behavior or the async client's typing.
+
+on:
+  schedule:
+    # Tuesday 7 AM UTC. Deliberately offset from the other recurring jobs
+    # (scheduled.yml: Monday 8 AM, tokenizer-drift.yml: Wednesday 7 AM,
+    # soak.yml: Thursday 9 AM) so they never contend for runners.
+    - cron: "0 7 * * 2"
+  workflow_dispatch:
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.13"
+      - run: uv sync --all-extras --group dev
+      # Deliberately bypass uv.lock's pinned redis version: this job exists to
+      # catch drift against whatever redis-py ships next, not to re-verify the
+      # client version already covered by ci.yml.
+      - run: uv pip install --upgrade redis
+      # --no-sync: plain `uv run` re-syncs the environment to uv.lock first,
+      # which would silently downgrade the redis upgrade above before either
+      # the type check or Redis-backed tests start.
+      - run: uv run --no-sync python -c "import redis; print(f'redis-py {redis.__version__}')"
+      - run: uv run --no-sync mypy
+      - run: uv run --no-sync pytest tests/integration tests/multiprocess -v --redis-url redis://localhost:6379/13
+        env:
+          TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE: "2"

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -15,9 +15,9 @@ name: Soak / Stress
 
 on:
   schedule:
-    # Thursday 9 AM UTC. Deliberately offset from the Monday 8 AM UTC
-    # "Scheduled Dependency Health" job (scheduled.yml) so the two recurring
-    # jobs never contend for runners or Redis.
+    # Thursday 9 AM UTC. Deliberately offset from the other recurring jobs
+    # (scheduled.yml: Monday 8 AM, redis-client-drift.yml: Tuesday 7 AM,
+    # tokenizer-drift.yml: Wednesday 7 AM) so they never contend for runners.
     - cron: "0 9 * * 4"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/tokenizer-drift.yml
+++ b/.github/workflows/tokenizer-drift.yml
@@ -11,9 +11,9 @@ name: Tokenizer Drift Canary
 
 on:
   schedule:
-    # Wednesday 7 AM UTC. Deliberately offset from the other two recurring
-    # jobs (scheduled.yml: Monday 8 AM UTC, soak.yml: Thursday 9 AM UTC) so
-    # the three never contend for runners.
+    # Wednesday 7 AM UTC. Deliberately offset from the other recurring jobs
+    # (scheduled.yml: Monday 8 AM, redis-client-drift.yml: Tuesday 7 AM,
+    # soak.yml: Thursday 9 AM) so they never contend for runners.
     - cron: "0 7 * * 3"
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 Notable changes for token-throttle releases. Each major version's breaking
 changes and upgrade steps are recorded in its entry below.
 
+## Unreleased
+
+- The `redis` extra now allows redis-py 8, and no longer caps at the next major:
+  the requirement is `redis>=5.2.1,!=8.0.0,!=8.0.1`. An upper bound in library
+  metadata cannot be relaxed without a release and causes resolution conflicts
+  for anything that needs a newer client, so future majors are permitted rather
+  than blocked on the assumption that they break. The two exclusions are
+  releases with specific defects — 8.0.0 breaks unix-socket clients, and
+  8.0.0/8.0.1 leak Sentinel connection-pool slots on every failover.
+  If you build your client the short way (`redis.from_url(...)`) and run more
+  than 100 concurrent acquires, pass `max_connections` explicitly: redis-py 8
+  caps the default pool where earlier versions effectively did not. See
+  [docs/operations.md](docs/operations.md#supported-redis-py-client-versions).
+
 ## 10.1.1 - 2026-08-27
 
 - Fixes the SQLite backends leaking a reservation from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ changes and upgrade steps are recorded in its entry below.
   than 100 concurrent acquires, pass `max_connections` explicitly: redis-py 8
   caps the default pool where earlier versions effectively did not. See
   [docs/operations.md](docs/operations.md#supported-redis-py-client-versions).
+- Fixes a refund whose reply was lost in transit being reported as
+  `DuplicateRefundError` even though that same call refunded successfully.
+  redis-py retries a command whose response never arrives, so the replayed
+  script found the refund-dedup record written by its own first execution and
+  reported a duplicate. The refund now carries a per-attempt token, so a replay
+  that finds its own record is reported as the success it was, while a genuine
+  second refund — including one issued after a process restart — still raises
+  `DuplicateRefundError`. Capacity accounting was always correct; only the
+  reported outcome was wrong. The window grows on redis-py 8, which raises the
+  default command-retry count from three to ten.
 
 ## 10.1.1 - 2026-08-27
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -108,12 +108,16 @@ database, discovered at run time rather than hardcoded, because these suites
 flush the database they are handed; preflight refuses to start rather than
 reuse a populated one.
 
-The floor and newest-client checks re-resolve dependencies, which rewrites
-`uv.lock` — `UV_PROJECT_ENVIRONMENT` redirects the virtualenv but not the
-lockfile, and a lock left recording a different resolution mode makes every
-later `uv run` re-sync your real environment. Those two checks therefore run
-against their own copy of the working tree, so the repository's lockfile is
-physically out of reach; preflight also verifies it is unchanged at the end.
+The version-varying checks build their environment with `uv pip install`
+rather than `uv sync`. This matters: `uv sync --resolution lowest-direct`
+rewrites `uv.lock` even when `UV_PROJECT_ENVIRONMENT` points the virtualenv
+elsewhere — that flag redirects the environment, not the lockfile — and a lock
+left recording a different resolution mode makes every later `uv run` re-sync
+your real environment, silently downgrading your tooling. `uv pip install` is
+pip-mode and neither reads nor writes the lockfile, so
+`uv pip install --resolution lowest-direct --python <venv> -e ".[redis]"
+--group dev` gets the floor without touching anything. Preflight also verifies
+the lockfile is unchanged at the end, and restores it loudly if it ever is not.
 Every run prints what it could not prove — Windows, Linux container specifics,
 CodeQL, and the Codecov upload still need a real CI run.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,6 +100,18 @@ The mypy gate checks the complete `token_throttle/` package with normal import
 following. Install all extras before running it because the checked package
 includes Redis, OpenAI, and tokenizer integration modules.
 
+**Type-check against the locked redis-py, not an older one.** The supported
+client range starts at `redis>=5.2.1`, and every admitted version runs the full
+suite correctly — but redis-py before 7.0 annotates the variadic arguments of
+`eval()` as `str`, while the backend passes the mix of strings, bytes, ints, and
+floats that Redis accepts at runtime. Type-checking this package's source
+against a 5.x or 6.x client therefore reports four `eval()` argument-type errors
+that describe the old annotation, not any real defect: those same versions pass
+the unit, conformance, and integration suites against a live server. The floor
+was deliberately kept at 5.2.1 rather than raised to silence them, because
+raising it would drop working clients for a typing artifact. `uv sync` installs
+the locked client, so this only appears if you deliberately downgrade.
+
 ## CI structure
 
 CI runs nine jobs (see `.github/workflows/ci.yml`):

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -108,12 +108,14 @@ database, discovered at run time rather than hardcoded, because these suites
 flush the database they are handed; preflight refuses to start rather than
 reuse a populated one.
 
-The floor and newest-client checks re-resolve dependencies, and
-`uv sync --resolution ...` rewrites `uv.lock` in the repository even when
-`UV_PROJECT_ENVIRONMENT` sends the virtualenv elsewhere. Those two therefore run
-serially, last, with the lockfile snapshotted and restored; a run that restores
-it says so. Every run also prints what it could not prove — Windows, Linux
-container specifics, CodeQL, and the Codecov upload still need a real CI run.
+The floor and newest-client checks re-resolve dependencies, which rewrites
+`uv.lock` — `UV_PROJECT_ENVIRONMENT` redirects the virtualenv but not the
+lockfile, and a lock left recording a different resolution mode makes every
+later `uv run` re-sync your real environment. Those two checks therefore run
+against their own copy of the working tree, so the repository's lockfile is
+physically out of reach; preflight also verifies it is unchanged at the end.
+Every run prints what it could not prove — Windows, Linux container specifics,
+CodeQL, and the Codecov upload still need a real CI run.
 
 ## Type checking
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,6 +89,32 @@ Name **new** test files `test_<area>_<behavior>.py` (e.g.
 `test_reservation_refund_dedup.py`), describing what is under test rather than
 which bug-tracker item introduced it.
 
+## Preflight: run the CI gates before pushing
+
+```bash
+task preflight            # every job that gates a pull request
+task preflight -- --quick # lint, types, unit, conformance, doc lints
+task preflight -- --full  # adds the 3.12/3.13/3.14 matrix
+```
+
+Hosted runners routinely queue for tens of minutes before a job starts, so a
+push that fails CI costs far more wall-clock time than the job durations
+suggest. Preflight runs the same gates here: the quick tier finishes in about
+90 seconds, and the default tier — which adds integration, multiprocess, the
+dependency floor, and the newest permitted redis-py — in about three minutes.
+
+Redis must be running. Each Redis-touching check is given its own empty logical
+database, discovered at run time rather than hardcoded, because these suites
+flush the database they are handed; preflight refuses to start rather than
+reuse a populated one.
+
+The floor and newest-client checks re-resolve dependencies, and
+`uv sync --resolution ...` rewrites `uv.lock` in the repository even when
+`UV_PROJECT_ENVIRONMENT` sends the virtualenv elsewhere. Those two therefore run
+serially, last, with the lockfile snapshotted and restored; a run that restores
+it says so. Every run also prints what it could not prove — Windows, Linux
+container specifics, CodeQL, and the Codecov upload still need a real CI run.
+
 ## Type checking
 
 ```bash
@@ -124,7 +150,7 @@ CI runs nine jobs (see `.github/workflows/ci.yml`):
 | `test-unit-full` | Unit tests with all optional deps on Linux / Python 3.12, 3.13, 3.14 | all extras + dev |
 | `test-unit-platform` | Unit tests with all optional deps on macOS and Windows / Python 3.13 | all extras + dev |
 | `test-integration` | Integration tests against Redis on Linux / Python 3.12, 3.13, 3.14 | all extras + dev |
-| `test-min-deps` | Unit tests with lowest direct dependency resolution on Linux / Python 3.12 | dev only |
+| `test-min-deps` | Unit and Redis integration tests at the lowest direct dependency resolution on Linux / Python 3.12 — this is what proves the declared `redis>=5.2.1` floor | redis extra + dev |
 | `conformance` | AST and structural conformance guards on Linux / Python 3.12 | all extras + dev |
 | `coverage` | Full suite + Codecov upload on Linux / Python 3.13 | all extras + dev |
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ Copy-paste runnable.
 ```python
 import asyncio
 
-from token_throttle import MemoryBackendBuilder, PerModelConfig, Quota, RateLimiter, UsageQuotas
+from token_throttle import (
+    MemoryBackendBuilder,
+    PerModelConfig,
+    Quota,
+    RateLimiter,
+    UsageQuotas,
+)
 
 
 async def main() -> None:
@@ -62,7 +68,6 @@ async def main() -> None:
 
     await limiter.aclose()
     print("reserved 1000 tokens, refunded 575 unused tokens")
-
 
 
 asyncio.run(main())
@@ -124,7 +129,10 @@ async def main() -> None:
     except Exception:
         await limiter.refund_capacity(
             reservation=reservation,
-            actual_usage={"requests": 1, "tokens": 0},  # zero-token refund on error is an approximation; reconcile against billing
+            actual_usage={
+                "requests": 1,
+                "tokens": 0,
+            },  # zero-token refund on error is an approximation; reconcile against billing
         )
         raise
     else:
@@ -158,7 +166,13 @@ The manual acquire -> refund pattern that `reserve()` wraps, with explicit error
 ```python
 import asyncio
 
-from token_throttle import MemoryBackendBuilder, PerModelConfig, Quota, RateLimiter, UsageQuotas
+from token_throttle import (
+    MemoryBackendBuilder,
+    PerModelConfig,
+    Quota,
+    RateLimiter,
+    UsageQuotas,
+)
 
 
 async def call_your_llm() -> dict[str, int]:
@@ -195,7 +209,9 @@ async def main() -> None:
         )
         raise
     else:
-        await limiter.refund_capacity(actual_usage=actual_usage, reservation=reservation)
+        await limiter.refund_capacity(
+            actual_usage=actual_usage, reservation=reservation
+        )
     finally:
         await limiter.aclose()
     print("unused 20 input tokens and 2800 output tokens returned to the pool")
@@ -248,11 +264,13 @@ are covered in [docs/operations.md](docs/operations.md#reservation-lifecycle-and
 ```python
 from token_throttle import Quota, UsageQuotas, SecondsIn
 
-quotas = UsageQuotas([
-    Quota(metric="requests", limit=2_000, per_seconds=SecondsIn.MINUTE),
-    Quota(metric="tokens", limit=3_000_000, per_seconds=SecondsIn.MINUTE),
-    Quota(metric="requests", limit=10_000_000, per_seconds=SecondsIn.DAY),
-])
+quotas = UsageQuotas(
+    [
+        Quota(metric="requests", limit=2_000, per_seconds=SecondsIn.MINUTE),
+        Quota(metric="tokens", limit=3_000_000, per_seconds=SecondsIn.MINUTE),
+        Quota(metric="requests", limit=10_000_000, per_seconds=SecondsIn.DAY),
+    ]
+)
 ```
 
 `per_seconds` accepts integer seconds. Use `SecondsIn.MINUTE` (60), `SecondsIn.HOUR` (3600), `SecondsIn.DAY` (86400), or any integer.
@@ -266,10 +284,12 @@ A quota with `limit=1` makes its window a minimum interval, so pacing needs no s
 ```python
 from token_throttle import Quota, SecondsIn, UsageQuotas
 
-quotas = UsageQuotas([
-    Quota(metric="requests", limit=1, per_seconds=3),                    # spacing
-    Quota(metric="requests", limit=20, per_seconds=SecondsIn.MINUTE),    # ceiling
-])
+quotas = UsageQuotas(
+    [
+        Quota(metric="requests", limit=1, per_seconds=3),  # spacing
+        Quota(metric="requests", limit=20, per_seconds=SecondsIn.MINUTE),  # ceiling
+    ]
+)
 ```
 
 Consecutive calls are then spaced 3 seconds apart, and the twenty-first within a minute waits for the window to release rather than for the spacing quota. Both are enforced together; neither supersedes the other.
@@ -281,14 +301,17 @@ Consecutive calls are then spaced 3 seconds apart, and the twenty-first within a
 def get_config(model_name: str) -> PerModelConfig:
     if model_name.startswith("gpt"):
         return PerModelConfig(
-            quotas=UsageQuotas([
-                Quota(metric="requests", limit=10_000, per_seconds=60),
-                Quota(metric="tokens", limit=2_000_000, per_seconds=60),
-            ]),
+            quotas=UsageQuotas(
+                [
+                    Quota(metric="requests", limit=10_000, per_seconds=60),
+                    Quota(metric="tokens", limit=2_000_000, per_seconds=60),
+                ]
+            ),
             usage_counter=OpenAIUsageCounter(),  # text-only: counts payload + instructions/tools/schema + output budget
             model_family=openai_model_family_getter(model_name),
         )
     # ... other providers
+
 
 limiter = RateLimiter(
     get_config,
@@ -323,10 +346,12 @@ for its clock, persistence, TTL, contention, and crash contracts.
 # (fragment — see Memory quickstart for standalone context)
 # Multiple machines
 from token_throttle import RedisBackendBuilder
+
 backend = RedisBackendBuilder(redis_client, key_prefix="my-service-prod")
 
 # Multiple processes on one host; stdlib only
 from token_throttle import SqliteBackendBuilder
+
 backend = SqliteBackendBuilder(
     "/var/lib/my-service/rate-limits.sqlite3",
     key_prefix="my-service-prod",
@@ -334,6 +359,7 @@ backend = SqliteBackendBuilder(
 
 # One process
 from token_throttle import MemoryBackendBuilder
+
 backend = MemoryBackendBuilder()
 ```
 
@@ -488,7 +514,9 @@ Both support context-manager close:
 ```python
 # (fragment — see Memory quickstart for standalone context)
 async with RateLimiter(get_config, backend=MemoryBackendBuilder()) as limiter:
-    reservation = await limiter.acquire_capacity({"requests": 1, "tokens": 500}, model="gpt-4.1")
+    reservation = await limiter.acquire_capacity(
+        {"requests": 1, "tokens": 500}, model="gpt-4.1"
+    )
     await limiter.refund_capacity({"requests": 1, "tokens": 320}, reservation)
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -39,6 +39,14 @@ tasks:
     desc: Run a quick memory-only acquire-path benchmark profile (numbers are machine-relative; see benchmarks/README.md)
     aliases: [b]
   ##############################
+  ### PREFLIGHT
+  ##############################
+  preflight:
+    cmds:
+      - uv run python -m devtools.preflight {{.CLI_ARGS}}
+    desc: Run the CI gates locally before pushing (add --quick or --full)
+    aliases: [pf]
+  ##############################
   ### LINT AND DEPENDENCIES
   ##############################
   lint:

--- a/devtools/preflight.py
+++ b/devtools/preflight.py
@@ -105,7 +105,10 @@ def _checks(tier: str) -> list[Check]:
     # UV_PROJECT_ENVIRONMENT points the virtualenv elsewhere, and a lock left
     # recording a different resolution mode makes every later `uv run` re-sync
     # the real environment. `uv pip install` is pip-mode and neither reads nor
-    # writes the lockfile.
+    # writes the lockfile. (`-e ".[redis]" --group dev` and
+    # `-r pyproject.toml --extra redis --group dev` were measured to resolve
+    # identically here — every direct dependency lands on its floor — and the
+    # editable form also installs the project itself.)
     checks += [
         Check(
             "integration",

--- a/devtools/preflight.py
+++ b/devtools/preflight.py
@@ -1,0 +1,353 @@
+"""
+Run the CI gates locally, before pushing.
+
+GitHub's hosted runners frequently queue for tens of minutes before a job
+starts, so a push that fails CI costs far more wall-clock time than the job
+itself suggests. This reproduces what CI checks, on this machine, so a red
+run becomes surprising rather than routine.
+
+Usage:
+    uv run python -m devtools.preflight            # default tier
+    uv run python -m devtools.preflight --quick    # fast feedback only
+    uv run python -m devtools.preflight --full     # + the Python matrix
+
+Tiers:
+    quick    lint, format, type-check, unit, conformance, doc lints
+    default  quick + integration, multiprocess, the dependency floor, and the
+             newest redis client -- i.e. every job that gates a pull request
+    full     default + the 3.12/3.13/3.14 matrix
+
+What this cannot prove is listed at the end of every run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Candidate logical databases, probed for emptiness at run time. Each
+# concurrent Redis-touching check needs its own: the suites flush around every
+# test, so sharing one produces phantom failures that look like product bugs.
+# DB 0 is never a candidate — it is the default a bare URL selects, and is the
+# most likely to hold something real.
+REDIS_DB_CANDIDATES = tuple(range(1, 16))
+REDIS_HOST = os.environ.get("PREFLIGHT_REDIS_HOST", "redis://localhost:6379")
+
+# Proven only by a real CI run; stated after every preflight so a green local
+# result is never mistaken for a green matrix.
+NOT_COVERED_LOCALLY = (
+    "Windows (test-unit-platform windows-latest) — no Windows host here",
+    "Linux specifics (container filesystem, service networking, umask)",
+    "CodeQL analysis",
+    "Codecov upload (needs the repository token and a real Actions run)",
+)
+
+
+@dataclass
+class Check:
+    name: str
+    argv: list[str]
+    tier: str = "quick"
+    needs_redis: bool = False
+    env: dict[str, str] = field(default_factory=dict)
+    # When set, run in a throwaway environment so the dev venv is never mutated.
+    isolated_python: str | None = None
+    pre_argv: list[list[str]] = field(default_factory=list)
+    # `uv sync --resolution ...` re-resolves and REWRITES uv.lock in the repo,
+    # even when UV_PROJECT_ENVIRONMENT points the venv elsewhere — that only
+    # redirects the environment, not the lockfile. Checks flagged here run
+    # serially, last, with the lockfile snapshotted and restored around them.
+    mutates_lockfile: bool = False
+
+
+@dataclass
+class Result:
+    check: Check
+    ok: bool
+    seconds: float
+    tail: str
+
+
+def _redis_url(db: int) -> str:
+    return f"{REDIS_HOST.rstrip('/')}/{db}"
+
+
+def _checks(tier: str) -> list[Check]:
+    """The local mirror of .github/workflows/ci.yml."""
+    checks: list[Check] = [
+        Check("lint", ["uv", "run", "ruff", "check", "."]),
+        Check("format", ["uv", "run", "ruff", "format", "--check", "."]),
+        Check("type-check", ["uv", "run", "mypy"]),
+        Check("unit", ["uv", "run", "pytest", "tests/unit", "-q"], needs_redis=True),
+        Check(
+            "conformance",
+            ["uv", "run", "pytest", "tests/conformance", "-q"],
+            needs_redis=True,
+        ),
+        Check("doc-lints", ["uv", "run", "pytest", "tests/lint", "-q"]),
+    ]
+    if tier == "quick":
+        return checks
+
+    checks += [
+        Check(
+            "integration",
+            ["uv", "run", "pytest", "tests/integration", "-q"],
+            tier="default",
+            needs_redis=True,
+        ),
+        Check(
+            "multiprocess",
+            ["uv", "run", "pytest", "tests/multiprocess", "-q"],
+            tier="default",
+            needs_redis=True,
+            env={"TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE": "2"},
+        ),
+        # Mirrors test-min-deps: the lowest client the metadata permits. This is
+        # the job that caught retry-replay tests depending on a version-specific
+        # default, which the locked client hid completely.
+        Check(
+            "dependency-floor",
+            [
+                "uv",
+                "run",
+                "--no-sync",
+                "pytest",
+                "tests/unit",
+                "tests/integration",
+                "-m",
+                "redis",
+                "-q",
+            ],
+            tier="default",
+            needs_redis=True,
+            isolated_python="3.12",
+            mutates_lockfile=True,
+            pre_argv=[
+                [
+                    "uv",
+                    "sync",
+                    "--extra",
+                    "redis",
+                    "--group",
+                    "dev",
+                    "--resolution",
+                    "lowest-direct",
+                ],
+            ],
+        ),
+        # Mirrors the scheduled drift canary: the newest client the uncapped
+        # range admits, which uv.lock otherwise pins away from.
+        Check(
+            "newest-redis-client",
+            [
+                "uv",
+                "run",
+                "--no-sync",
+                "pytest",
+                "tests/unit",
+                "tests/integration",
+                "-m",
+                "redis",
+                "-q",
+            ],
+            tier="default",
+            needs_redis=True,
+            isolated_python="3.13",
+            mutates_lockfile=True,
+            pre_argv=[
+                ["uv", "sync", "--all-extras", "--group", "dev"],
+                ["uv", "pip", "install", "--upgrade", "redis"],
+            ],
+        ),
+    ]
+    if tier != "full":
+        return checks
+
+    for version in ("3.12", "3.13", "3.14"):
+        checks.append(
+            Check(
+                f"unit-py{version}",
+                ["uv", "run", "--no-sync", "pytest", "tests/unit", "-q"],
+                tier="full",
+                needs_redis=True,
+                isolated_python=version,
+                pre_argv=[["uv", "sync", "--all-extras", "--group", "dev"]],
+            )
+        )
+    return checks
+
+
+def _run(check: Check, db: int | None) -> Result:
+    env = os.environ.copy()
+    env.update(check.env)
+    scratch: str | None = None
+    if check.isolated_python is not None:
+        # A separate environment keeps version-swapping checks from mutating
+        # the dev venv -- an interrupted run must not leave a downgraded client
+        # installed.
+        scratch = tempfile.mkdtemp(prefix="tt-preflight-")
+        env["UV_PROJECT_ENVIRONMENT"] = str(Path(scratch) / "venv")
+        env["UV_PYTHON"] = check.isolated_python
+
+    argv = list(check.argv)
+    if check.needs_redis and db is not None:
+        argv += ["--redis-url", _redis_url(db)]
+
+    started = time.monotonic()
+    try:
+        for pre in check.pre_argv:
+            done = subprocess.run(
+                pre, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=False
+            )
+            if done.returncode != 0:
+                return Result(
+                    check,
+                    ok=False,
+                    seconds=time.monotonic() - started,
+                    tail=f"setup failed: {' '.join(pre)}\n{done.stderr.strip()[-800:]}",
+                )
+        done = subprocess.run(
+            argv, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=False
+        )
+        output = (done.stdout + done.stderr).strip()
+        return Result(
+            check,
+            ok=done.returncode == 0,
+            seconds=time.monotonic() - started,
+            tail="\n".join(output.splitlines()[-12:]),
+        )
+    finally:
+        if scratch is not None:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+
+def _redis_reachable() -> bool:
+    probe = shutil.which("redis-cli")
+    if probe is None:
+        return False
+    done = subprocess.run([probe, "ping"], capture_output=True, text=True, check=False)
+    return done.returncode == 0 and "PONG" in done.stdout
+
+
+def _empty_redis_dbs(needed: int) -> list[int]:
+    """
+    Return `needed` logical databases that are currently empty.
+
+    Probed rather than hardcoded: another project (or another preflight) may
+    be holding keys in any given index, and handing a check a populated
+    database means it either refuses to run or destroys someone's data.
+    Returns fewer than requested if that many are not free; the caller decides.
+    """
+    probe = shutil.which("redis-cli")
+    if probe is None:
+        return []
+    free: list[int] = []
+    for db in REDIS_DB_CANDIDATES:
+        done = subprocess.run(
+            [probe, "-n", str(db), "dbsize"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if done.returncode == 0 and done.stdout.strip() == "0":
+            free.append(db)
+        if len(free) == needed:
+            break
+    return free
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--quick", action="store_true", help="fast feedback only")
+    group.add_argument("--full", action="store_true", help="add the Python matrix")
+    parser.add_argument(
+        "--jobs", type=int, default=4, help="checks to run concurrently (default 4)"
+    )
+    args = parser.parse_args()
+
+    tier = "quick" if args.quick else "full" if args.full else "default"
+    checks = _checks(tier)
+
+    if not _redis_reachable() and any(c.needs_redis for c in checks):
+        print(
+            "Redis is not answering at "
+            f"{REDIS_HOST}. Start it before preflighting: the Redis-backed "
+            "suites are where most CI surprises live.",
+            file=sys.stderr,
+        )
+        return 2
+
+    redis_checks = [c for c in checks if c.needs_redis]
+    free_dbs = _empty_redis_dbs(len(redis_checks))
+    if len(free_dbs) < len(redis_checks):
+        print(
+            f"Need {len(redis_checks)} empty Redis databases but found "
+            f"{len(free_dbs)}. These suites flush the database they are given, "
+            "so preflight will not reuse a populated one. Free some up, or run "
+            "with --jobs 1 --quick for the checks that need no Redis.",
+            file=sys.stderr,
+        )
+        return 2
+    assigned: dict[str, int | None] = {c.name: None for c in checks}
+    for check, db in zip(redis_checks, free_dbs, strict=False):
+        assigned[check.name] = db
+
+    concurrent = [c for c in checks if not c.mutates_lockfile]
+    serial = [c for c in checks if c.mutates_lockfile]
+
+    print(f"preflight [{tier}] — {len(checks)} checks, {args.jobs} at a time\n")
+    started = time.monotonic()
+    results: list[Result] = []
+
+    def record(result: Result) -> None:
+        results.append(result)
+        mark = "PASS" if result.ok else "FAIL"
+        print(f"  {mark}  {result.check.name:<22} {result.seconds:6.1f}s", flush=True)
+
+    with ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        futures = [pool.submit(_run, c, assigned[c.name]) for c in concurrent]
+        for future in as_completed(futures):
+            record(future.result())
+
+    # Re-resolution rewrites uv.lock in place, so these run one at a time, after
+    # everything that reads the lockfile has finished, and the file is put back
+    # exactly as found. A dev tool that silently upgrades pinned dependencies is
+    # worse than no dev tool.
+    if serial:
+        lockfile = REPO_ROOT / "uv.lock"
+        snapshot = lockfile.read_bytes() if lockfile.exists() else None
+        try:
+            for check in serial:
+                record(_run(check, assigned[check.name]))
+        finally:
+            if snapshot is not None and lockfile.read_bytes() != snapshot:
+                lockfile.write_bytes(snapshot)
+                print("  ..    uv.lock was rewritten by a re-resolution; restored")
+
+    failed = [r for r in results if not r.ok]
+    print(
+        f"\n{len(results) - len(failed)}/{len(results)} passed "
+        f"in {time.monotonic() - started:.0f}s wall clock"
+    )
+    for result in failed:
+        print(f"\n----- {result.check.name} -----\n{result.tail}")
+    print("\nNot covered locally — only a real CI run proves these:")
+    for item in NOT_COVERED_LOCALLY:
+        print(f"  - {item}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/preflight.py
+++ b/devtools/preflight.py
@@ -7,15 +7,9 @@ itself suggests. This reproduces what CI checks, on this machine, so a red
 run becomes surprising rather than routine.
 
 Usage:
-    uv run python -m devtools.preflight            # default tier
-    uv run python -m devtools.preflight --quick    # fast feedback only
-    uv run python -m devtools.preflight --full     # + the Python matrix
-
-Tiers:
-    quick    lint, format, type-check, unit, conformance, doc lints
-    default  quick + integration, multiprocess, the dependency floor, and the
-             newest redis client -- i.e. every job that gates a pull request
-    full     default + the 3.12/3.13/3.14 matrix
+    task preflight              # every job that gates a pull request
+    task preflight -- --quick   # lint, types, unit, conformance, doc lints
+    task preflight -- --full    # adds the 3.12/3.13/3.14 matrix
 
 What this cannot prove is listed at the end of every run.
 """
@@ -38,12 +32,15 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # Candidate logical databases, probed for emptiness at run time. Each
 # concurrent Redis-touching check needs its own: the suites flush around every
 # test, so sharing one produces phantom failures that look like product bugs.
-# DB 0 is never a candidate — it is the default a bare URL selects, and is the
-# most likely to hold something real.
+# DB 0 is never a candidate — it is what a bare URL selects and the most likely
+# to hold something real.
 REDIS_DB_CANDIDATES = tuple(range(1, 16))
 REDIS_HOST = os.environ.get("PREFLIGHT_REDIS_HOST", "redis://localhost:6379")
 
-# Proven only by a real CI run; stated after every preflight so a green local
+# Substituted with the check's throwaway virtualenv path.
+VENV = "{venv}"
+
+# Proven only by a real CI run; printed after every preflight so a green local
 # result is never mistaken for a green matrix.
 NOT_COVERED_LOCALLY = (
     "Windows (test-unit-platform windows-latest) — no Windows host here",
@@ -57,19 +54,12 @@ NOT_COVERED_LOCALLY = (
 class Check:
     name: str
     argv: list[str]
-    tier: str = "quick"
     needs_redis: bool = False
     env: dict[str, str] = field(default_factory=dict)
-    # When set, run in a throwaway environment so the dev venv is never mutated.
-    isolated_python: str | None = None
+    # Build a throwaway virtualenv on this Python first. Commands may reference
+    # it as `{venv}`.
+    venv_python: str | None = None
     pre_argv: list[list[str]] = field(default_factory=list)
-    # `uv sync --resolution ...` re-resolves and REWRITES uv.lock in the repo,
-    # even when UV_PROJECT_ENVIRONMENT points the venv elsewhere — that only
-    # redirects the environment, not the lockfile. Worse, a lock left recording
-    # a different resolution mode makes every later `uv run` re-sync the real
-    # environment. Checks flagged here get their own copy of the working tree,
-    # and still run serially and last as a second line of defence.
-    mutates_lockfile: bool = False
 
 
 @dataclass
@@ -84,9 +74,17 @@ def _redis_url(db: int) -> str:
     return f"{REDIS_HOST.rstrip('/')}/{db}"
 
 
+def _pytest(venv: str, *targets: str) -> list[str]:
+    return [f"{venv}/bin/python", "-m", "pytest", *targets, "-q"]
+
+
+def _pip_install(*args: str) -> list[str]:
+    return ["uv", "pip", "install", "--python", VENV, "-q", *args]
+
+
 def _checks(tier: str) -> list[Check]:
     """The local mirror of .github/workflows/ci.yml."""
-    checks: list[Check] = [
+    checks = [
         Check("lint", ["uv", "run", "ruff", "check", "."]),
         Check("format", ["uv", "run", "ruff", "format", "--check", "."]),
         Check("type-check", ["uv", "run", "mypy"]),
@@ -101,75 +99,49 @@ def _checks(tier: str) -> list[Check]:
     if tier == "quick":
         return checks
 
+    # The version-varying checks below install into a throwaway virtualenv with
+    # `uv pip install` rather than `uv sync`. That is deliberate and measured:
+    # `uv sync --resolution ...` rewrites the project's uv.lock even when
+    # UV_PROJECT_ENVIRONMENT points the virtualenv elsewhere, and a lock left
+    # recording a different resolution mode makes every later `uv run` re-sync
+    # the real environment. `uv pip install` is pip-mode and neither reads nor
+    # writes the lockfile.
     checks += [
         Check(
             "integration",
             ["uv", "run", "pytest", "tests/integration", "-q"],
-            tier="default",
             needs_redis=True,
         ),
         Check(
             "multiprocess",
             ["uv", "run", "pytest", "tests/multiprocess", "-q"],
-            tier="default",
             needs_redis=True,
             env={"TOKEN_THROTTLE_MULTIPROCESS_TIMING_SCALE": "2"},
         ),
         # Mirrors test-min-deps: the lowest client the metadata permits. This is
-        # the job that caught retry-replay tests depending on a version-specific
-        # default, which the locked client hid completely.
+        # the check that caught retry-replay tests depending on a
+        # version-specific default, which the locked client hid entirely.
         Check(
             "dependency-floor",
-            [
-                "uv",
-                "run",
-                "--no-sync",
-                "pytest",
-                "tests/unit",
-                "tests/integration",
-                "-m",
-                "redis",
-                "-q",
-            ],
-            tier="default",
+            _pytest(VENV, "tests/unit", "tests/integration", "-m", "redis"),
             needs_redis=True,
-            isolated_python="3.12",
-            mutates_lockfile=True,
+            venv_python="3.12",
             pre_argv=[
-                [
-                    "uv",
-                    "sync",
-                    "--extra",
-                    "redis",
-                    "--group",
-                    "dev",
-                    "--resolution",
-                    "lowest-direct",
-                ],
+                _pip_install(
+                    "--resolution", "lowest-direct", "-e", ".[redis]", "--group", "dev"
+                ),
             ],
         ),
         # Mirrors the scheduled drift canary: the newest client the uncapped
         # range admits, which uv.lock otherwise pins away from.
         Check(
             "newest-redis-client",
-            [
-                "uv",
-                "run",
-                "--no-sync",
-                "pytest",
-                "tests/unit",
-                "tests/integration",
-                "-m",
-                "redis",
-                "-q",
-            ],
-            tier="default",
+            _pytest(VENV, "tests/unit", "tests/integration", "-m", "redis"),
             needs_redis=True,
-            isolated_python="3.13",
-            mutates_lockfile=True,
+            venv_python="3.13",
             pre_argv=[
-                ["uv", "sync", "--all-extras", "--group", "dev"],
-                ["uv", "pip", "install", "--upgrade", "redis"],
+                _pip_install("-e", ".[redis,tiktoken]", "--group", "dev"),
+                _pip_install("--upgrade", "redis"),
             ],
         ),
     ]
@@ -180,91 +152,65 @@ def _checks(tier: str) -> list[Check]:
         checks.append(
             Check(
                 f"unit-py{version}",
-                ["uv", "run", "--no-sync", "pytest", "tests/unit", "-q"],
-                tier="full",
+                _pytest(VENV, "tests/unit"),
                 needs_redis=True,
-                isolated_python=version,
-                pre_argv=[["uv", "sync", "--all-extras", "--group", "dev"]],
+                venv_python=version,
+                pre_argv=[_pip_install("-e", ".[redis,tiktoken]", "--group", "dev")],
             )
         )
     return checks
 
 
-_COPY_SKIP = frozenset(
-    {
-        ".git",
-        ".venv",
-        ".worktrees",
-        "__pycache__",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-        ".hypothesis",
-        "dist",
-        "htmlcov",
-        "node_modules",
-    }
-)
-
-
-def _copy_project(destination: Path) -> None:
-    """Copy the working tree so a check can re-resolve without touching it."""
-    shutil.copytree(
-        REPO_ROOT,
-        destination,
-        ignore=shutil.ignore_patterns(*_COPY_SKIP),
-        symlinks=True,
-    )
+def _substitute(argv: list[str], venv: str | None) -> list[str]:
+    if venv is None:
+        return list(argv)
+    return [part.replace(VENV, venv) for part in argv]
 
 
 def _run(check: Check, db: int | None) -> Result:
     env = os.environ.copy()
     env.update(check.env)
     scratch: str | None = None
-    cwd = REPO_ROOT
-    if check.isolated_python is not None:
-        # A separate environment keeps version-swapping checks from mutating
-        # the dev venv -- an interrupted run must not leave a downgraded client
-        # installed.
-        scratch = tempfile.mkdtemp(prefix="tt-preflight-")
-        env["UV_PROJECT_ENVIRONMENT"] = str(Path(scratch) / "venv")
-        env["UV_PYTHON"] = check.isolated_python
-    if check.mutates_lockfile:
-        # UV_PROJECT_ENVIRONMENT redirects the virtualenv but NOT the lockfile:
-        # `uv sync --resolution ...` still rewrites uv.lock in place, and a lock
-        # left recording a different resolution mode makes every later `uv run`
-        # re-sync the real environment. Give these checks their own copy of the
-        # tree so the repository's lockfile is physically out of reach.
-        if scratch is None:
-            scratch = tempfile.mkdtemp(prefix="tt-preflight-")
-            env["UV_PROJECT_ENVIRONMENT"] = str(Path(scratch) / "venv")
-        cwd = Path(scratch) / "project"
-        _copy_project(cwd)
-        env["UV_PROJECT_ENVIRONMENT"] = str(Path(scratch) / "venv")
-
-    argv = list(check.argv)
-    if check.needs_redis and db is not None:
-        argv += ["--redis-url", _redis_url(db)]
-
+    venv: str | None = None
     started = time.monotonic()
+
     try:
-        for pre in check.pre_argv:
+        commands = list(check.pre_argv)
+        if check.venv_python is not None:
+            scratch = tempfile.mkdtemp(prefix="tt-preflight-")
+            venv = str(Path(scratch) / "venv")
+            commands.insert(
+                0, ["uv", "venv", venv, "-q", "--python", check.venv_python]
+            )
+
+        for pre in commands:
+            resolved = _substitute(pre, venv)
             done = subprocess.run(
-                pre, cwd=cwd, env=env, capture_output=True, text=True, check=False
+                resolved,
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
             )
             if done.returncode != 0:
                 return Result(
-                    check,
+                    check=check,
                     ok=False,
                     seconds=time.monotonic() - started,
-                    tail=f"setup failed: {' '.join(pre)}\n{done.stderr.strip()[-800:]}",
+                    tail=f"setup failed: {' '.join(resolved)}\n"
+                    f"{(done.stdout + done.stderr).strip()[-800:]}",
                 )
+
+        argv = _substitute(check.argv, venv)
+        if check.needs_redis and db is not None:
+            argv += ["--redis-url", _redis_url(db)]
         done = subprocess.run(
-            argv, cwd=cwd, env=env, capture_output=True, text=True, check=False
+            argv, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=False
         )
         output = (done.stdout + done.stderr).strip()
         return Result(
-            check,
+            check=check,
             ok=done.returncode == 0,
             seconds=time.monotonic() - started,
             tail="\n".join(output.splitlines()[-12:]),
@@ -287,9 +233,8 @@ def _empty_redis_dbs(needed: int) -> list[int]:
     Return `needed` logical databases that are currently empty.
 
     Probed rather than hardcoded: another project (or another preflight) may
-    be holding keys in any given index, and handing a check a populated
-    database means it either refuses to run or destroys someone's data.
-    Returns fewer than requested if that many are not free; the caller decides.
+    hold keys in any given index, and handing a check a populated database
+    means it either refuses to run or destroys someone's data.
     """
     probe = shutil.which("redis-cli")
     if probe is None:
@@ -324,59 +269,48 @@ def main() -> int:
 
     if not _redis_reachable() and any(c.needs_redis for c in checks):
         print(
-            "Redis is not answering at "
-            f"{REDIS_HOST}. Start it before preflighting: the Redis-backed "
-            "suites are where most CI surprises live.",
+            f"Redis is not answering at {REDIS_HOST}. Start it before "
+            "preflighting: the Redis-backed suites are where most CI surprises "
+            "live.",
             file=sys.stderr,
         )
         return 2
 
     redis_checks = [c for c in checks if c.needs_redis]
-    free_dbs = _empty_redis_dbs(len(redis_checks))
-    if len(free_dbs) < len(redis_checks):
+    free = _empty_redis_dbs(len(redis_checks))
+    if len(free) < len(redis_checks):
         print(
-            f"Need {len(redis_checks)} empty Redis databases but found "
-            f"{len(free_dbs)}. These suites flush the database they are given, "
-            "so preflight will not reuse a populated one. Free some up, or run "
-            "with --jobs 1 --quick for the checks that need no Redis.",
+            f"Need {len(redis_checks)} empty Redis databases, found {len(free)}. "
+            "These suites flush the database they are handed, so preflight will "
+            "not reuse a populated one. Free some up, or use --quick.",
             file=sys.stderr,
         )
         return 2
     assigned: dict[str, int | None] = {c.name: None for c in checks}
-    for check, db in zip(redis_checks, free_dbs, strict=False):
+    for check, db in zip(redis_checks, free, strict=False):
         assigned[check.name] = db
 
-    concurrent = [c for c in checks if not c.mutates_lockfile]
-    serial = [c for c in checks if c.mutates_lockfile]
+    lockfile = REPO_ROOT / "uv.lock"
+    lock_before = lockfile.read_bytes() if lockfile.exists() else None
 
     print(f"preflight [{tier}] — {len(checks)} checks, {args.jobs} at a time\n")
     started = time.monotonic()
     results: list[Result] = []
-
-    def record(result: Result) -> None:
-        results.append(result)
-        mark = "PASS" if result.ok else "FAIL"
-        print(f"  {mark}  {result.check.name:<22} {result.seconds:6.1f}s", flush=True)
-
     with ThreadPoolExecutor(max_workers=args.jobs) as pool:
-        futures = [pool.submit(_run, c, assigned[c.name]) for c in concurrent]
+        futures = [pool.submit(_run, c, assigned[c.name]) for c in checks]
         for future in as_completed(futures):
-            record(future.result())
+            result = future.result()
+            results.append(result)
+            mark = "PASS" if result.ok else "FAIL"
+            print(
+                f"  {mark}  {result.check.name:<22} {result.seconds:6.1f}s", flush=True
+            )
 
-    # Re-resolution rewrites uv.lock in place, so these run one at a time, after
-    # everything that reads the lockfile has finished, and the file is put back
-    # exactly as found. A dev tool that silently upgrades pinned dependencies is
-    # worse than no dev tool.
-    if serial:
-        lockfile = REPO_ROOT / "uv.lock"
-        snapshot = lockfile.read_bytes() if lockfile.exists() else None
-        try:
-            for check in serial:
-                record(_run(check, assigned[check.name]))
-        finally:
-            if snapshot is not None and lockfile.read_bytes() != snapshot:
-                lockfile.write_bytes(snapshot)
-                print("  ..    uv.lock changed unexpectedly; restored")
+    # Nothing here should touch the lockfile. If that ever changes, say so
+    # loudly rather than leaving a silently mutated dependency set behind.
+    if lock_before is not None and lockfile.read_bytes() != lock_before:
+        lockfile.write_bytes(lock_before)
+        print("\n!! uv.lock was modified by a check and has been restored")
 
     failed = [r for r in results if not r.ok]
     print(

--- a/devtools/preflight.py
+++ b/devtools/preflight.py
@@ -65,8 +65,10 @@ class Check:
     pre_argv: list[list[str]] = field(default_factory=list)
     # `uv sync --resolution ...` re-resolves and REWRITES uv.lock in the repo,
     # even when UV_PROJECT_ENVIRONMENT points the venv elsewhere — that only
-    # redirects the environment, not the lockfile. Checks flagged here run
-    # serially, last, with the lockfile snapshotted and restored around them.
+    # redirects the environment, not the lockfile. Worse, a lock left recording
+    # a different resolution mode makes every later `uv run` re-sync the real
+    # environment. Checks flagged here get their own copy of the working tree,
+    # and still run serially and last as a second line of defence.
     mutates_lockfile: bool = False
 
 
@@ -188,10 +190,38 @@ def _checks(tier: str) -> list[Check]:
     return checks
 
 
+_COPY_SKIP = frozenset(
+    {
+        ".git",
+        ".venv",
+        ".worktrees",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".hypothesis",
+        "dist",
+        "htmlcov",
+        "node_modules",
+    }
+)
+
+
+def _copy_project(destination: Path) -> None:
+    """Copy the working tree so a check can re-resolve without touching it."""
+    shutil.copytree(
+        REPO_ROOT,
+        destination,
+        ignore=shutil.ignore_patterns(*_COPY_SKIP),
+        symlinks=True,
+    )
+
+
 def _run(check: Check, db: int | None) -> Result:
     env = os.environ.copy()
     env.update(check.env)
     scratch: str | None = None
+    cwd = REPO_ROOT
     if check.isolated_python is not None:
         # A separate environment keeps version-swapping checks from mutating
         # the dev venv -- an interrupted run must not leave a downgraded client
@@ -199,6 +229,18 @@ def _run(check: Check, db: int | None) -> Result:
         scratch = tempfile.mkdtemp(prefix="tt-preflight-")
         env["UV_PROJECT_ENVIRONMENT"] = str(Path(scratch) / "venv")
         env["UV_PYTHON"] = check.isolated_python
+    if check.mutates_lockfile:
+        # UV_PROJECT_ENVIRONMENT redirects the virtualenv but NOT the lockfile:
+        # `uv sync --resolution ...` still rewrites uv.lock in place, and a lock
+        # left recording a different resolution mode makes every later `uv run`
+        # re-sync the real environment. Give these checks their own copy of the
+        # tree so the repository's lockfile is physically out of reach.
+        if scratch is None:
+            scratch = tempfile.mkdtemp(prefix="tt-preflight-")
+            env["UV_PROJECT_ENVIRONMENT"] = str(Path(scratch) / "venv")
+        cwd = Path(scratch) / "project"
+        _copy_project(cwd)
+        env["UV_PROJECT_ENVIRONMENT"] = str(Path(scratch) / "venv")
 
     argv = list(check.argv)
     if check.needs_redis and db is not None:
@@ -208,7 +250,7 @@ def _run(check: Check, db: int | None) -> Result:
     try:
         for pre in check.pre_argv:
             done = subprocess.run(
-                pre, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=False
+                pre, cwd=cwd, env=env, capture_output=True, text=True, check=False
             )
             if done.returncode != 0:
                 return Result(
@@ -218,7 +260,7 @@ def _run(check: Check, db: int | None) -> Result:
                     tail=f"setup failed: {' '.join(pre)}\n{done.stderr.strip()[-800:]}",
                 )
         done = subprocess.run(
-            argv, cwd=REPO_ROOT, env=env, capture_output=True, text=True, check=False
+            argv, cwd=cwd, env=env, capture_output=True, text=True, check=False
         )
         output = (done.stdout + done.stderr).strip()
         return Result(
@@ -334,7 +376,7 @@ def main() -> int:
         finally:
             if snapshot is not None and lockfile.read_bytes() != snapshot:
                 lockfile.write_bytes(snapshot)
-                print("  ..    uv.lock was rewritten by a re-resolution; restored")
+                print("  ..    uv.lock changed unexpectedly; restored")
 
     failed = [r for r in results if not r.ok]
     print(

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -92,6 +92,7 @@ receive these events without changing existing callback signatures:
 # (fragment — see the README Any provider example for standalone context)
 from token_throttle import LifecycleEvent, RateLimiterCallbacks
 
+
 async def on_lifecycle_event(*, event: LifecycleEvent) -> None:
     metrics.increment(
         f"token_throttle.{event.event_type}",
@@ -100,6 +101,7 @@ async def on_lifecycle_event(*, event: LifecycleEvent) -> None:
             "model_alias": event.model_alias,
         },
     )
+
 
 limiter = RateLimiter(
     get_config,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -125,6 +125,31 @@ Do not add caller-controlled Redis hash tags to key prefixes, model families,
 metrics, reservation ids, or other key segments. Public validators reject `{`
 and `}` in Redis key segments, and Cluster support is intentionally unsupported.
 
+### Supported redis-py client versions
+
+The `redis` extra declares `redis>=5.2.1,!=8.0.0,!=8.0.1` — deliberately with
+**no upper bound**. A ceiling in a library's metadata cannot be relaxed without
+publishing a release, and it propagates into dependency-resolution conflicts for
+anyone who depends on both this package and a newer client. So a new redis-py
+major is allowed by default rather than blocked on the assumption it will break.
+
+The two exclusions are specific defects, not caution:
+
+| Excluded | Why |
+|---|---|
+| `8.0.0` | unix-socket clients fail the RESP3 maintenance-notification handshake ([redis-py#4086](https://github.com/redis/redis-py/issues/4086)) |
+| `8.0.0`, `8.0.1` | the sync Sentinel pool permanently loses a slot on every failover until all commands raise `MaxConnectionsError` ([redis-py#4187](https://github.com/redis/redis-py/issues/4187), fixed in 8.1.0) — and Sentinel is a supported topology here |
+
+An open-ended range is a promise about versions that do not exist yet, so it is
+backed by a scheduled job that installs the newest redis-py and runs the Redis
+suites against it. If a future release breaks the backend, that job goes red
+before your deployment does; the fix is then either a code change or a new
+exclusion with the same kind of evidence as the two above.
+
+If you pin a client version yourself, note the pool-sizing change in
+[Connection pooling](#connection-pooling-and-key-ttls) — redis-py 8 caps the
+default pool where earlier versions did not.
+
 Redis backends require Redis server 6.2 or newer and a Redis user that can run
 `GET`, `EXISTS`, `SET`, `DEL`, `EXPIRE`, `PEXPIRE`, `PTTL`, `TIME`, `MULTI`,
 `EXEC`, `DISCARD`, and Lua scripting (`EVAL`, `EVALSHA`, `SCRIPT LOAD`).
@@ -184,6 +209,16 @@ or `redis.BlockingConnectionPool` and size `max_connections` to at least
 `max_concurrent_acquires` plus headroom for Redis lock acquire/release, `TIME`,
 and pipeline commands. A pool below 10 connections triggers a runtime warning
 because it is usually too small for production traffic.
+
+**Size the pool explicitly on redis-py 8 and newer.** redis-py 8 lowered the
+default `ConnectionPool` cap from effectively unbounded to 100 connections, and
+raises `MaxConnectionsError` once they are all checked out. A client built the
+short way — `redis.from_url(...)`, as the README quickstarts show — silently
+inherits that cap, while token-throttle's own default ceiling on in-flight
+reservations is 100,000 and it imposes no Redis-side concurrency limit of its
+own. Below-10 pools warn; a 100-connection default does not, because it is not
+obviously wrong. If your workload can have more than 100 acquires in flight at
+once, pass `max_connections` yourself rather than inheriting the default.
 
 Redis bucket state expires by default after 7 days of inactivity. Configure
 `bucket_ttl_seconds` on Redis builders or Redis OpenAI factories to choose a

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -93,14 +93,18 @@ Both limiter types can own their close lifecycle through context managers:
 ```python
 # (fragment — see the README Memory quickstart for standalone context)
 async with RateLimiter(get_config, backend=MemoryBackendBuilder()) as limiter:
-    reservation = await limiter.acquire_capacity({"requests": 1, "tokens": 500}, model="gpt-4.1")
+    reservation = await limiter.acquire_capacity(
+        {"requests": 1, "tokens": 500}, model="gpt-4.1"
+    )
     await limiter.refund_capacity({"requests": 1, "tokens": 320}, reservation)
 ```
 
 ```python
 # (fragment — see the README Sync API example for standalone context)
 with SyncRateLimiter(get_config, backend=SyncMemoryBackendBuilder()) as limiter:
-    reservation = limiter.acquire_capacity({"requests": 1, "tokens": 500}, model="gpt-4.1")
+    reservation = limiter.acquire_capacity(
+        {"requests": 1, "tokens": 500}, model="gpt-4.1"
+    )
     limiter.refund_capacity({"requests": 1, "tokens": 320}, reservation)
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -140,11 +140,18 @@ The two exclusions are specific defects, not caution:
 | `8.0.0` | unix-socket clients fail the RESP3 maintenance-notification handshake ([redis-py#4086](https://github.com/redis/redis-py/issues/4086)) |
 | `8.0.0`, `8.0.1` | the sync Sentinel pool permanently loses a slot on every failover until all commands raise `MaxConnectionsError` ([redis-py#4187](https://github.com/redis/redis-py/issues/4187), fixed in 8.1.0) — and Sentinel is a supported topology here |
 
+Every admitted major was exercised against a live server before the range was
+widened — 5.2.1 (the floor), 5.3.1, 6.4.0, 7.0.0, 7.4.1, and 8.1.0 each ran the
+full unit, conformance, and integration suites and passed. The two excluded
+releases had their defects reproduced locally rather than taken on faith from
+the upstream issues.
+
 An open-ended range is a promise about versions that do not exist yet, so it is
 backed by a scheduled job that installs the newest redis-py and runs the Redis
-suites against it. If a future release breaks the backend, that job goes red
-before your deployment does; the fix is then either a code change or a new
-exclusion with the same kind of evidence as the two above.
+suites against it, and by a job that pins the declared floor. If a future
+release breaks the backend, those go red before your deployment does; the fix is
+then either a code change or a new exclusion with the same kind of evidence as
+the two above.
 
 If you pin a client version yourself, note the pool-sizing change in
 [Connection pooling](#connection-pooling-and-key-ttls) — redis-py 8 caps the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ target-version = "py312"
     "T201",    # print() statement found
     "C901",    # Function is too complex
     "PLR0912", # Too many branches
+    "S603",    # these scripts shell out by design; every argv is a literal
 ]
 "benchmarks/**/*.py" = [
     "T201",     # print() is the benchmark table/report output channel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.12"
 dependencies = ["frozendict>=2.4.6,<3", "pydantic>=2.12.0,<3"]
 
 [project.optional-dependencies]
-redis = ["redis>=5.2.1,<8"]
+redis = ["redis>=5.2.1,!=8.0.0,!=8.0.1"]
 tiktoken = ["tiktoken>=0.10.0,<1"]
 
 [project.urls]

--- a/tests/integration/test_redis_fault_injection.py
+++ b/tests/integration/test_redis_fault_injection.py
@@ -94,6 +94,16 @@ def _sync_capacity(sync_redis_client, key: str) -> float | None:
     return None if value is None else float(value)
 
 
+def _default_retry_client_kwargs(redis_client) -> dict[str, object]:
+    """Copy address/auth fields without copying the fixture pool's retry policy."""
+    pool_kwargs = redis_client.connection_pool.connection_kwargs
+    return {
+        name: pool_kwargs[name]
+        for name in ("host", "port", "db", "username", "password")
+        if pool_kwargs.get(name) is not None
+    }
+
+
 # ---------------------------------------------------------------------------
 # 0. Redis Lua authority ordering
 # ---------------------------------------------------------------------------
@@ -831,3 +841,152 @@ class TestConnectionErrorDuringRefund:
         assert cap_after == pytest.approx(cap_before, abs=2.0), (
             f"Partial refund committed! Before={cap_before}, after={cap_after}."
         )
+
+
+# ---------------------------------------------------------------------------
+# 7. Lost refund reply replayed by redis-py
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.redis
+async def test_async_lost_refund_reply_replay_is_reported_as_success(
+    redis_client,
+    monkeypatch,
+):
+    """A committed refund remains successful when redis-py replays its EVAL."""
+    retrying_client = aioredis.Redis(**_default_retry_client_kwargs(redis_client))
+    prefix = "retry-replay-async"
+    config = _make_config(limit=100, per_seconds=3600)
+    limiter = RateLimiter(
+        config,
+        backend=RedisBackendBuilder(retrying_client, key_prefix=prefix),
+    )
+    refund_eval_attempts = 0
+    reply_dropped = False
+
+    try:
+        reservation = await limiter.acquire_capacity(
+            {"requests": 30.0},
+            config.get_model_family(),
+            timeout=0,
+        )
+        backend = await limiter._get_backend(config)
+        bucket = backend.sorted_buckets[0]
+        original_send_and_parse = retrying_client._send_command_parse_response
+
+        async def drop_first_refund_eval_reply(
+            conn,
+            command_name,
+            *args,
+            **options,
+        ):
+            nonlocal refund_eval_attempts, reply_dropped
+            result = await original_send_and_parse(
+                conn,
+                command_name,
+                *args,
+                **options,
+            )
+            if command_name == "EVAL":
+                refund_eval_attempts += 1
+                if not reply_dropped:
+                    reply_dropped = True
+                    raise redis.exceptions.ConnectionError(
+                        "injected lost refund reply after server commit"
+                    )
+            return result
+
+        monkeypatch.setattr(
+            retrying_client,
+            "_send_command_parse_response",
+            drop_first_refund_eval_reply,
+        )
+
+        await limiter.refund_capacity({"requests": 10.0}, reservation)
+
+        assert reply_dropped
+        assert refund_eval_attempts == 2
+        assert (
+            await redis_client.exists(
+                redis_acquired_marker_key(prefix, reservation.reservation_id)
+            )
+            == 0
+        )
+        assert (
+            await redis_client.exists(
+                redis_refund_dedup_key(prefix, reservation.reservation_id)
+            )
+            == 1
+        )
+        assert await _async_capacity(
+            redis_client, bucket._capacity_key
+        ) == pytest.approx(90.0, abs=1.0)
+    finally:
+        await retrying_client.aclose()
+
+
+@pytest.mark.redis
+def test_sync_lost_refund_reply_replay_is_reported_as_success(
+    sync_redis_client,
+    monkeypatch,
+):
+    """The synchronous backend has the same retry-replay semantics."""
+    retrying_client = redis.Redis(**_default_retry_client_kwargs(sync_redis_client))
+    prefix = "retry-replay-sync"
+    config = _make_config(limit=100, per_seconds=3600)
+    limiter = SyncRateLimiter(
+        config,
+        backend=SyncRedisBackendBuilder(retrying_client, key_prefix=prefix),
+    )
+    refund_eval_attempts = 0
+    reply_dropped = False
+
+    try:
+        reservation = limiter.acquire_capacity(
+            {"requests": 30.0},
+            config.get_model_family(),
+            timeout=0,
+        )
+        backend = limiter._get_backend(config)
+        bucket = backend.sorted_buckets[0]
+        original_send_and_parse = retrying_client._send_command_parse_response
+
+        def drop_first_refund_eval_reply(conn, command_name, *args, **options):
+            nonlocal refund_eval_attempts, reply_dropped
+            result = original_send_and_parse(conn, command_name, *args, **options)
+            if command_name == "EVAL":
+                refund_eval_attempts += 1
+                if not reply_dropped:
+                    reply_dropped = True
+                    raise redis.exceptions.ConnectionError(
+                        "injected lost refund reply after server commit"
+                    )
+            return result
+
+        monkeypatch.setattr(
+            retrying_client,
+            "_send_command_parse_response",
+            drop_first_refund_eval_reply,
+        )
+
+        limiter.refund_capacity({"requests": 10.0}, reservation)
+
+        assert reply_dropped
+        assert refund_eval_attempts == 2
+        assert (
+            sync_redis_client.exists(
+                redis_acquired_marker_key(prefix, reservation.reservation_id)
+            )
+            == 0
+        )
+        assert (
+            sync_redis_client.exists(
+                redis_refund_dedup_key(prefix, reservation.reservation_id)
+            )
+            == 1
+        )
+        assert _sync_capacity(sync_redis_client, bucket._capacity_key) == pytest.approx(
+            90.0, abs=1.0
+        )
+    finally:
+        retrying_client.close()

--- a/tests/integration/test_redis_fault_injection.py
+++ b/tests/integration/test_redis_fault_injection.py
@@ -25,7 +25,7 @@ import redis.asyncio as aioredis
 import redis.exceptions
 from frozendict import frozendict
 
-from token_throttle._exceptions import BackendLockContentionError
+from token_throttle._exceptions import BackendLockContentionError, DuplicateRefundError
 from token_throttle._interfaces._callbacks import RateLimiterCallbacks
 from token_throttle._interfaces._interfaces import PerModelConfig
 from token_throttle._interfaces._models import Quota, UsageQuotas
@@ -921,6 +921,29 @@ async def test_async_lost_refund_reply_replay_is_reported_as_success(
         assert await _async_capacity(
             redis_client, bucket._capacity_key
         ) == pytest.approx(90.0, abs=1.0)
+
+        monkeypatch.setattr(
+            retrying_client,
+            "_send_command_parse_response",
+            original_send_and_parse,
+        )
+        restarted_backend = RedisBackendBuilder(
+            retrying_client,
+            key_prefix=prefix,
+        ).build(config)
+        with pytest.raises(DuplicateRefundError, match="reservation already refunded"):
+            await restarted_backend.refund_capacity_for_buckets(
+                frozendict({"requests": 30.0}),
+                frozendict({"requests": 10.0}),
+                bucket_ids=reservation.bucket_ids,
+                reservation_id=reservation.reservation_id,
+                reservation_model_family=reservation.model_family,
+                reservation_bucket_ids=reservation.bucket_ids,
+                reservation_reserved_usage=reservation.get_usage(),
+            )
+        assert await _async_capacity(
+            redis_client, bucket._capacity_key
+        ) == pytest.approx(90.0, abs=1.0)
     finally:
         await retrying_client.aclose()
 
@@ -985,6 +1008,29 @@ def test_sync_lost_refund_reply_replay_is_reported_as_success(
             )
             == 1
         )
+        assert _sync_capacity(sync_redis_client, bucket._capacity_key) == pytest.approx(
+            90.0, abs=1.0
+        )
+
+        monkeypatch.setattr(
+            retrying_client,
+            "_send_command_parse_response",
+            original_send_and_parse,
+        )
+        restarted_backend = SyncRedisBackendBuilder(
+            retrying_client,
+            key_prefix=prefix,
+        ).build(config)
+        with pytest.raises(DuplicateRefundError, match="reservation already refunded"):
+            restarted_backend.refund_capacity_for_buckets(
+                frozendict({"requests": 30.0}),
+                frozendict({"requests": 10.0}),
+                bucket_ids=reservation.bucket_ids,
+                reservation_id=reservation.reservation_id,
+                reservation_model_family=reservation.model_family,
+                reservation_bucket_ids=reservation.bucket_ids,
+                reservation_reserved_usage=reservation.get_usage(),
+            )
         assert _sync_capacity(sync_redis_client, bucket._capacity_key) == pytest.approx(
             90.0, abs=1.0
         )

--- a/tests/integration/test_redis_fault_injection.py
+++ b/tests/integration/test_redis_fault_injection.py
@@ -24,6 +24,8 @@ pytest.importorskip("redis", reason="redis package not installed")
 import redis.asyncio as aioredis
 import redis.exceptions
 from frozendict import frozendict
+from redis.backoff import NoBackoff
+from redis.retry import Retry
 
 from token_throttle._exceptions import BackendLockContentionError, DuplicateRefundError
 from token_throttle._interfaces._callbacks import RateLimiterCallbacks
@@ -94,14 +96,48 @@ def _sync_capacity(sync_redis_client, key: str) -> float | None:
     return None if value is None else float(value)
 
 
-def _default_retry_client_kwargs(redis_client) -> dict[str, object]:
-    """Copy address/auth fields without copying the fixture pool's retry policy."""
+def _address_kwargs(redis_client) -> dict[str, object]:
+    """Address/auth fields only, without the fixture pool's retry policy."""
     pool_kwargs = redis_client.connection_pool.connection_kwargs
     return {
         name: pool_kwargs[name]
         for name in ("host", "port", "db", "username", "password")
         if pool_kwargs.get(name) is not None
     }
+
+
+def _sync_retrying_client_kwargs(redis_client) -> dict[str, object]:
+    """Address fields plus an explicit command-retry policy.
+
+    Set explicitly rather than inherited: the default varies across the
+    supported client range (redis-py 5.2.1 installs no command retry, 8.x
+    retries ten times), and a replay test that relied on the default would
+    silently exercise nothing on older clients. Measured to replay on both
+    5.2.1 and 8.1.0 for the synchronous client.
+    """
+    kwargs = _address_kwargs(redis_client)
+    kwargs["retry"] = Retry(NoBackoff(), 3)
+    kwargs["retry_on_error"] = [redis.exceptions.ConnectionError]
+    return kwargs
+
+
+def _skip_unless_async_client_replays(client) -> None:
+    """Skip when this redis-py version will not replay an async command.
+
+    The asynchronous client cannot be coerced into a uniform replay policy the
+    way the synchronous one can: on 5.2.1 no combination of ``retry`` /
+    ``retry_on_error`` replays a failed command, and on 8.x passing an explicit
+    ``retry`` *disables* the replay that the default performs. So this path is
+    exercised wherever the installed client replays by default, and skipped —
+    visibly — where it cannot, rather than asserting something the client
+    never does.
+    """
+    retry = client.connection_pool.connection_kwargs.get("retry")
+    if retry is None or getattr(retry, "_retries", 0) < 1:
+        pytest.skip(
+            f"redis-py {redis.__version__} does not retry async commands by "
+            "default, so a transport replay cannot be provoked"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -854,7 +890,8 @@ async def test_async_lost_refund_reply_replay_is_reported_as_success(
     monkeypatch,
 ):
     """A committed refund remains successful when redis-py replays its EVAL."""
-    retrying_client = aioredis.Redis(**_default_retry_client_kwargs(redis_client))
+    retrying_client = aioredis.Redis(**_address_kwargs(redis_client))
+    _skip_unless_async_client_replays(retrying_client)
     prefix = "retry-replay-async"
     config = _make_config(limit=100, per_seconds=3600)
     limiter = RateLimiter(
@@ -954,7 +991,7 @@ def test_sync_lost_refund_reply_replay_is_reported_as_success(
     monkeypatch,
 ):
     """The synchronous backend has the same retry-replay semantics."""
-    retrying_client = redis.Redis(**_default_retry_client_kwargs(sync_redis_client))
+    retrying_client = redis.Redis(**_sync_retrying_client_kwargs(sync_redis_client))
     prefix = "retry-replay-sync"
     config = _make_config(limit=100, per_seconds=3600)
     limiter = SyncRateLimiter(

--- a/tests/lint/test_readme_standalone_examples.py
+++ b/tests/lint/test_readme_standalone_examples.py
@@ -128,7 +128,7 @@ _EXPECTED_NON_PYTHON_FENCES = (
     ),
     _ExpectedNonPythonFence(
         document_name="README.md",
-        start_line=93,
+        start_line=98,
         language="bash",
         classification=_NON_PYTHON_CLASSIFICATION_SHELL_SYNTAX,
         reason="package installation command; lint syntax-checks but does not execute it",
@@ -186,6 +186,19 @@ _EXPECTED_NON_PYTHON_FENCES = (
     _ExpectedNonPythonFence(
         document_name="DEVELOPMENT.md",
         start_line=95,
+        language="bash",
+        classification=_NON_PYTHON_CLASSIFICATION_SHELL_SYNTAX,
+        reason="preflight task invocations; lint syntax-checks but does not execute them",
+        heading="## Preflight: run the CI gates before pushing",
+        non_empty_content_lines=(
+            "task preflight            # every job that gates a pull request",
+            "task preflight -- --quick # lint, types, unit, conformance, doc lints",
+            "task preflight -- --full  # adds the 3.12/3.13/3.14 matrix",
+        ),
+    ),
+    _ExpectedNonPythonFence(
+        document_name="DEVELOPMENT.md",
+        start_line=121,
         language="bash",
         classification=_NON_PYTHON_CLASSIFICATION_SHELL_SYNTAX,
         reason="setup and type-check commands; lint syntax-checks but does not execute them",
@@ -260,7 +273,7 @@ _EXPECTED_TASKFILE_RELEASE_DISPATCHES = (
 _EXPECTED_NON_README_STANDALONE_IDENTITIES = (
     _StandaloneExampleIdentity(
         document_name="DEVELOPMENT.md",
-        start_line=450,
+        start_line=476,
         heading="### Redis connection pool sizing",
         first_non_empty_code_line="import redis.asyncio as aioredis",
     ),
@@ -275,7 +288,7 @@ _EXPECTED_STDOUT_EXAMPLES = (
     ),
     _ExpectedStdoutExample(
         document_name="README.md",
-        start_line=159,
+        start_line=167,
         heading="### Any provider (manual usage)",
         first_non_empty_code_line="import asyncio",
         expected_stdout=(

--- a/tests/lint/test_readme_standalone_examples.py
+++ b/tests/lint/test_readme_standalone_examples.py
@@ -198,7 +198,7 @@ _EXPECTED_NON_PYTHON_FENCES = (
     ),
     _ExpectedNonPythonFence(
         document_name="DEVELOPMENT.md",
-        start_line=123,
+        start_line=127,
         language="bash",
         classification=_NON_PYTHON_CLASSIFICATION_SHELL_SYNTAX,
         reason="setup and type-check commands; lint syntax-checks but does not execute them",
@@ -273,7 +273,7 @@ _EXPECTED_TASKFILE_RELEASE_DISPATCHES = (
 _EXPECTED_NON_README_STANDALONE_IDENTITIES = (
     _StandaloneExampleIdentity(
         document_name="DEVELOPMENT.md",
-        start_line=478,
+        start_line=482,
         heading="### Redis connection pool sizing",
         first_non_empty_code_line="import redis.asyncio as aioredis",
     ),

--- a/tests/lint/test_readme_standalone_examples.py
+++ b/tests/lint/test_readme_standalone_examples.py
@@ -260,7 +260,7 @@ _EXPECTED_TASKFILE_RELEASE_DISPATCHES = (
 _EXPECTED_NON_README_STANDALONE_IDENTITIES = (
     _StandaloneExampleIdentity(
         document_name="DEVELOPMENT.md",
-        start_line=438,
+        start_line=450,
         heading="### Redis connection pool sizing",
         first_non_empty_code_line="import redis.asyncio as aioredis",
     ),

--- a/tests/lint/test_readme_standalone_examples.py
+++ b/tests/lint/test_readme_standalone_examples.py
@@ -198,7 +198,7 @@ _EXPECTED_NON_PYTHON_FENCES = (
     ),
     _ExpectedNonPythonFence(
         document_name="DEVELOPMENT.md",
-        start_line=121,
+        start_line=123,
         language="bash",
         classification=_NON_PYTHON_CLASSIFICATION_SHELL_SYNTAX,
         reason="setup and type-check commands; lint syntax-checks but does not execute them",
@@ -273,7 +273,7 @@ _EXPECTED_TASKFILE_RELEASE_DISPATCHES = (
 _EXPECTED_NON_README_STANDALONE_IDENTITIES = (
     _StandaloneExampleIdentity(
         document_name="DEVELOPMENT.md",
-        start_line=476,
+        start_line=478,
         heading="### Redis connection pool sizing",
         first_non_empty_code_line="import redis.asyncio as aioredis",
     ),

--- a/tests/unit/test_bundle_acquire_marker_authority.py
+++ b/tests/unit/test_bundle_acquire_marker_authority.py
@@ -178,16 +178,15 @@ class _AsyncRedis:
             marker_key, dedup_key = keys[0], keys[1]
             marker = await self.get(marker_key)
             if marker is None:
-                return (
-                    "duplicate_refund"
-                    if await self.exists(dedup_key)
-                    else "unknown_reservation"
-                )
+                tombstone = await self.get(dedup_key)
+                if tombstone == argv[2]:
+                    return "replayed_refund"
+                return "duplicate_refund" if tombstone else "unknown_reservation"
             if marker != argv[0]:
                 return "marker_mismatch"
             if await self.exists(dedup_key):
                 return "incoherent_refund"
-            arg_index = 2
+            arg_index = 3
             for key_index in range(2, len(keys), 2):
                 await self.set(
                     keys[key_index], argv[arg_index], ex=int(argv[arg_index + 2])
@@ -199,7 +198,12 @@ class _AsyncRedis:
                 )
                 arg_index += 3
             await self.delete(marker_key)
-            claimed = await self.set(dedup_key, "1", ex=int(argv[1]), nx=True)
+            claimed = await self.set(
+                dedup_key,
+                argv[2],
+                ex=int(argv[1]),
+                nx=True,
+            )
             if not claimed:
                 return "incoherent_refund"
             return "ok"
@@ -333,16 +337,15 @@ class _SyncRedis:
             marker_key, dedup_key = keys[0], keys[1]
             marker = self.get(marker_key)
             if marker is None:
-                return (
-                    "duplicate_refund"
-                    if self.exists(dedup_key)
-                    else "unknown_reservation"
-                )
+                tombstone = self.get(dedup_key)
+                if tombstone == argv[2]:
+                    return "replayed_refund"
+                return "duplicate_refund" if tombstone else "unknown_reservation"
             if marker != argv[0]:
                 return "marker_mismatch"
             if self.exists(dedup_key):
                 return "incoherent_refund"
-            arg_index = 2
+            arg_index = 3
             for key_index in range(2, len(keys), 2):
                 self.set(keys[key_index], argv[arg_index], ex=int(argv[arg_index + 2]))
                 self.set(
@@ -352,7 +355,12 @@ class _SyncRedis:
                 )
                 arg_index += 3
             self.delete(marker_key)
-            claimed = self.set(dedup_key, "1", ex=int(argv[1]), nx=True)
+            claimed = self.set(
+                dedup_key,
+                argv[2],
+                ex=int(argv[1]),
+                nx=True,
+            )
             if not claimed:
                 return "incoherent_refund"
             return "ok"
@@ -508,7 +516,8 @@ async def test_async_redis_happy_path_deletes_marker_and_writes_tombstone() -> N
     await limiter.refund_capacity({"tokens": 10}, reservation)
 
     assert marker_key not in redis_client.store
-    assert redis_client.store[tombstone_key] == "1"
+    assert isinstance(redis_client.store[tombstone_key], str)
+    assert redis_client.store[tombstone_key] != "1"
     assert (
         redis_client.store[f"{PREFIX}:rate_limiting:bucket:{FAMILY}:tokens:60:capacity"]
         == 90.0
@@ -528,7 +537,8 @@ def test_sync_redis_happy_path_deletes_marker_and_writes_tombstone() -> None:
     limiter.refund_capacity({"tokens": 10}, reservation)
 
     assert marker_key not in redis_client.store
-    assert redis_client.store[tombstone_key] == "1"
+    assert isinstance(redis_client.store[tombstone_key], str)
+    assert redis_client.store[tombstone_key] != "1"
     assert (
         redis_client.store[f"{PREFIX}:rate_limiting:bucket:{FAMILY}:tokens:60:capacity"]
         == 90.0
@@ -596,10 +606,11 @@ async def test_async_redis_cross_limiter_refund_rejects_shared_marker() -> None:
         redis_acquired_marker_key(PREFIX, reservation.reservation_id)
         not in redis_client.store
     )
-    assert (
-        redis_client.store[redis_refund_dedup_key(PREFIX, reservation.reservation_id)]
-        == "1"
-    )
+    tombstone = redis_client.store[
+        redis_refund_dedup_key(PREFIX, reservation.reservation_id)
+    ]
+    assert isinstance(tombstone, str)
+    assert tombstone != "1"
 
 
 @_REDIS_SKIP
@@ -619,10 +630,11 @@ def test_sync_redis_cross_limiter_refund_rejects_shared_marker() -> None:
         redis_acquired_marker_key(PREFIX, reservation.reservation_id)
         not in redis_client.store
     )
-    assert (
-        redis_client.store[redis_refund_dedup_key(PREFIX, reservation.reservation_id)]
-        == "1"
-    )
+    tombstone = redis_client.store[
+        redis_refund_dedup_key(PREFIX, reservation.reservation_id)
+    ]
+    assert isinstance(tombstone, str)
+    assert tombstone != "1"
 
 
 @_REDIS_SKIP

--- a/tests/unit/test_bundle_refund_idempotency_transaction.py
+++ b/tests/unit/test_bundle_refund_idempotency_transaction.py
@@ -287,16 +287,15 @@ class _AsyncRedis:
         marker_key, dedup_key = keys[0], keys[1]
         marker = await self.get(marker_key)
         if marker is None:
-            return (
-                "duplicate_refund"
-                if await self.exists(dedup_key)
-                else "unknown_reservation"
-            )
+            tombstone = await self.get(dedup_key)
+            if tombstone == argv[2]:
+                return "replayed_refund"
+            return "duplicate_refund" if tombstone else "unknown_reservation"
         if marker != argv[0]:
             return "marker_mismatch"
         if await self.exists(dedup_key):
             return "incoherent_refund"
-        arg_index = 2
+        arg_index = 3
         for key_index in range(2, len(keys), 2):
             await self.set(
                 keys[key_index], argv[arg_index], ex=int(argv[arg_index + 2])
@@ -308,7 +307,7 @@ class _AsyncRedis:
             )
             arg_index += 3
         await self.delete(marker_key)
-        claimed = await self.set(dedup_key, "1", ex=int(argv[1]), nx=True)
+        claimed = await self.set(dedup_key, argv[2], ex=int(argv[1]), nx=True)
         if not claimed:
             return "incoherent_refund"
         return "ok"
@@ -380,14 +379,15 @@ class _SyncRedis:
         marker_key, dedup_key = keys[0], keys[1]
         marker = self.get(marker_key)
         if marker is None:
-            return (
-                "duplicate_refund" if self.exists(dedup_key) else "unknown_reservation"
-            )
+            tombstone = self.get(dedup_key)
+            if tombstone == argv[2]:
+                return "replayed_refund"
+            return "duplicate_refund" if tombstone else "unknown_reservation"
         if marker != argv[0]:
             return "marker_mismatch"
         if self.exists(dedup_key):
             return "incoherent_refund"
-        arg_index = 2
+        arg_index = 3
         for key_index in range(2, len(keys), 2):
             self.set(keys[key_index], argv[arg_index], ex=int(argv[arg_index + 2]))
             self.set(
@@ -397,7 +397,7 @@ class _SyncRedis:
             )
             arg_index += 3
         self.delete(marker_key)
-        claimed = self.set(dedup_key, "1", ex=int(argv[1]), nx=True)
+        claimed = self.set(dedup_key, argv[2], ex=int(argv[1]), nx=True)
         if not claimed:
             return "incoherent_refund"
         return "ok"
@@ -541,7 +541,8 @@ async def test_async_redis_failed_bucket_write_does_not_claim_tombstone() -> Non
         **_marker_refund_kwargs("redis-r1"),
     )
     assert redis_client.store[bucket._capacity_key] == 90.0
-    assert redis_client.store[dedup_key] == "1"
+    assert isinstance(redis_client.store[dedup_key], str)
+    assert redis_client.store[dedup_key] != "1"
 
     with pytest.raises(DuplicateRefundError, match="reservation already refunded"):
         await backend.refund_capacity_for_buckets(
@@ -585,7 +586,8 @@ def test_sync_redis_failed_bucket_write_does_not_claim_tombstone() -> None:
         **_marker_refund_kwargs("redis-r2"),
     )
     assert redis_client.store[bucket._capacity_key] == 90.0
-    assert redis_client.store[dedup_key] == "1"
+    assert isinstance(redis_client.store[dedup_key], str)
+    assert redis_client.store[dedup_key] != "1"
 
     with pytest.raises(DuplicateRefundError, match="reservation already refunded"):
         backend.refund_capacity_for_buckets(
@@ -625,5 +627,6 @@ async def test_async_redis_deferred_tombstone_serializes_concurrent_retries() ->
 
     assert results.count(True) == 1
     assert sum(isinstance(result, DuplicateRefundError) for result in results) == 1
-    assert redis_client.store[dedup_key] == "1"
+    assert isinstance(redis_client.store[dedup_key], str)
+    assert redis_client.store[dedup_key] != "1"
     assert redis_client.store[bucket._capacity_key] == 90.0

--- a/tests/unit/test_fix_45_redis_marker_reconciliation.py
+++ b/tests/unit/test_fix_45_redis_marker_reconciliation.py
@@ -252,7 +252,8 @@ async def test_async_lost_refund_eval_reply_commits_local_state() -> None:
     marker_key = redis_acquired_marker_key(PREFIX, reservation.reservation_id)
     tombstone_key = redis_refund_dedup_key(PREFIX, reservation.reservation_id)
     assert marker_key not in redis_client.store
-    assert redis_client.store[tombstone_key] == "1"
+    assert isinstance(redis_client.store[tombstone_key], str)
+    assert redis_client.store[tombstone_key] != "1"
     assert redis_client.store[_CAPACITY_KEY] == 90.0
     assert limiter._refunded_reservation_ids[reservation.reservation_id] == "committed"
     assert reservation.reservation_id not in limiter._in_flight_reservation_ids
@@ -271,7 +272,8 @@ def test_sync_lost_refund_eval_reply_commits_local_state() -> None:
     marker_key = redis_acquired_marker_key(PREFIX, reservation.reservation_id)
     tombstone_key = redis_refund_dedup_key(PREFIX, reservation.reservation_id)
     assert marker_key not in redis_client.store
-    assert redis_client.store[tombstone_key] == "1"
+    assert isinstance(redis_client.store[tombstone_key], str)
+    assert redis_client.store[tombstone_key] != "1"
     assert redis_client.store[_CAPACITY_KEY] == 90.0
     assert limiter._refunded_reservation_ids[reservation.reservation_id] == "committed"
     assert reservation.reservation_id not in limiter._in_flight_reservation_ids

--- a/token_throttle/_limiter_backends/_redis/_backend.py
+++ b/token_throttle/_limiter_backends/_redis/_backend.py
@@ -257,7 +257,11 @@ local function rollback_then_error(snapshots, err)
 end
 local marker = redis.call('GET', KEYS[1])
 if not marker then
-    if redis.call('EXISTS', KEYS[2]) == 1 then
+    local tombstone = redis.call('GET', KEYS[2])
+    if tombstone == ARGV[3] then
+        return 'replayed_refund'
+    end
+    if tombstone then
         return 'duplicate_refund'
     end
     return 'unknown_reservation'
@@ -272,7 +276,7 @@ local snapshots = {snapshot_key(KEYS[1]), snapshot_key(KEYS[2])}
 for key_index = 3, #KEYS do
     snapshots[#snapshots + 1] = snapshot_key(KEYS[key_index])
 end
-local arg_index = 3
+local arg_index = 4
 for key_index = 3, #KEYS, 2 do
     local last_checked_set = redis.pcall(
         'SET', KEYS[key_index], ARGV[arg_index], 'EX', ARGV[arg_index + 2]
@@ -292,7 +296,7 @@ local marker_deleted = redis.pcall('DEL', KEYS[1])
 if is_error(marker_deleted) then
     return rollback_then_error(snapshots, marker_deleted)
 end
-local claimed = redis.pcall('SET', KEYS[2], '1', 'EX', ARGV[2], 'NX')
+local claimed = redis.pcall('SET', KEYS[2], ARGV[3], 'EX', ARGV[2], 'NX')
 if is_error(claimed) then
     return rollback_then_error(snapshots, claimed)
 end
@@ -1977,9 +1981,14 @@ class RedisBackend(RateLimiterBackend):
             bucket_id=None,
         )
         keys: list[str] = [acquired_marker_key, refund_dedup_key]
+        # redis-py replays the same EVAL arguments after an ambiguous transport
+        # failure. A new backend invocation gets a new token, so only that
+        # internal replay can recognize the tombstone as its own commit.
+        refund_attempt_token = uuid.uuid4().hex
         args: list[str | bytes | int | float] = [
             acquired_marker_value,
             self._refund_dedup_ttl_seconds,
+            refund_attempt_token,
         ]
         for (usage_metric, per_seconds), amount in new_capacities.items():
             matching_bucket = self._find_bucket(
@@ -2031,6 +2040,8 @@ class RedisBackend(RateLimiterBackend):
             result, context="RedisBackend refund marker script"
         )
         if status == "ok":
+            return
+        if status == "replayed_refund":
             return
         if status == "duplicate_refund":
             raise DuplicateRefundError(

--- a/token_throttle/_limiter_backends/_redis/_sync_backend.py
+++ b/token_throttle/_limiter_backends/_redis/_sync_backend.py
@@ -253,7 +253,11 @@ local function rollback_then_error(snapshots, err)
 end
 local marker = redis.call('GET', KEYS[1])
 if not marker then
-    if redis.call('EXISTS', KEYS[2]) == 1 then
+    local tombstone = redis.call('GET', KEYS[2])
+    if tombstone == ARGV[3] then
+        return 'replayed_refund'
+    end
+    if tombstone then
         return 'duplicate_refund'
     end
     return 'unknown_reservation'
@@ -268,7 +272,7 @@ local snapshots = {snapshot_key(KEYS[1]), snapshot_key(KEYS[2])}
 for key_index = 3, #KEYS do
     snapshots[#snapshots + 1] = snapshot_key(KEYS[key_index])
 end
-local arg_index = 3
+local arg_index = 4
 for key_index = 3, #KEYS, 2 do
     local last_checked_set = redis.pcall(
         'SET', KEYS[key_index], ARGV[arg_index], 'EX', ARGV[arg_index + 2]
@@ -288,7 +292,7 @@ local marker_deleted = redis.pcall('DEL', KEYS[1])
 if is_error(marker_deleted) then
     return rollback_then_error(snapshots, marker_deleted)
 end
-local claimed = redis.pcall('SET', KEYS[2], '1', 'EX', ARGV[2], 'NX')
+local claimed = redis.pcall('SET', KEYS[2], ARGV[3], 'EX', ARGV[2], 'NX')
 if is_error(claimed) then
     return rollback_then_error(snapshots, claimed)
 end
@@ -1837,9 +1841,14 @@ class SyncRedisBackend(SyncRateLimiterBackend):
             bucket_id=None,
         )
         keys: list[str] = [acquired_marker_key, refund_dedup_key]
+        # redis-py replays the same EVAL arguments after an ambiguous transport
+        # failure. A new backend invocation gets a new token, so only that
+        # internal replay can recognize the tombstone as its own commit.
+        refund_attempt_token = uuid.uuid4().hex
         args: list[str | bytes | int | float] = [
             acquired_marker_value,
             self._refund_dedup_ttl_seconds,
+            refund_attempt_token,
         ]
         for (usage_metric, per_seconds), amount in new_capacities.items():
             matching_bucket = self._find_bucket(
@@ -1888,6 +1897,8 @@ class SyncRedisBackend(SyncRateLimiterBackend):
             result, context="SyncRedisBackend refund marker script"
         )
         if status == "ok":
+            return
+        if status == "replayed_refund":
             return
         if status == "duplicate_refund":
             raise DuplicateRefundError(

--- a/uv.lock
+++ b/uv.lock
@@ -856,11 +856,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "7.4.1"
+version = "8.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/93/05e7d4a65285066a74f48697f9b9cde5cfce71398033d69ed83c3d98f5c9/redis-7.4.1.tar.gz", hash = "sha256:1a1df5067062cf7cbe677994e391f8ee0840f499d370f1a71266e0dd3aa9308e", size = 4945742, upload-time = "2026-06-05T09:10:06.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/2e/2677f3f93dae0497e7e33b6637302e7f3744efc553f34231183e32584885/redis-7.4.1-py3-none-any.whl", hash = "sha256:1fa4647af1c5e93a2c685aa248ee44cce092691146d41390518dabe9a99839b0", size = 410171, upload-time = "2026-06-05T09:10:05.128Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ dev = [
 requires-dist = [
     { name = "frozendict", specifier = ">=2.4.6,<3" },
     { name = "pydantic", specifier = ">=2.12.0,<3" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.2.1,<8" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.2.1,!=8.0.0,!=8.0.1" },
     { name = "tiktoken", marker = "extra == 'tiktoken'", specifier = ">=0.10.0,<1" },
 ]
 provides-extras = ["redis", "tiktoken"]


### PR DESCRIPTION
Replaces the `<8` ceiling with **`redis>=5.2.1,!=8.0.0,!=8.0.1`** — deliberately uncapped.

## Why no upper bound

A ceiling in a *library's* metadata can't be relaxed without publishing a release, and it propagates into dependency-resolution conflicts for anyone who needs both this package and a newer client. Moving the wall to `<9` would just require moving it again. So a future redis-py major is allowed by default rather than blocked on the assumption it breaks — with the two exclusions being releases that have specific, **locally reproduced** defects rather than caution:

| Excluded | Defect |
|---|---|
| `8.0.0` | unix-socket clients fail the RESP3 maintenance-notification handshake ([redis-py#4086](https://github.com/redis/redis-py/issues/4086)) |
| `8.0.0`, `8.0.1` | sync Sentinel pool permanently loses a slot per failover until every command raises `MaxConnectionsError` ([redis-py#4187](https://github.com/redis/redis-py/issues/4187)) — Sentinel is a supported topology here |

## Verified, not assumed

Every admitted major ran the full unit, conformance, and integration suites against a live server: **5.2.1** (the floor), 5.3.1, 6.4.0, 7.0.0, 7.4.1, 8.1.0 — all pass. Both exclusions had their defects reproduced locally rather than taken on faith from the issue links.

An uncapped range is a promise about versions that don't exist yet, so it's backed by CI at both ends: a **scheduled drift canary** that installs the newest unpinned redis-py and runs the Redis suites plus mypy against it (mirroring the existing tokenizer-drift canary, staggered so the recurring jobs never contend for runners), and a **floor job** that pins the lowest permitted client — previously `test-min-deps` synced without extras, so the declared `>=5.2.1` floor had never actually been exercised.

## Also fixes the retry-replay duplicate refund (#21)

redis-py retries a command whose reply never arrives. If a refund's Lua script committed but its response was lost, the replay found the dedup record written by its own first execution and raised `DuplicateRefundError` — for a call that *did* refund. This gets likelier on redis-py 8, which raises the default retry count from three to ten, so shipping 8 support without addressing it would have been shipping a known sharp edge.

The refund now carries a per-attempt token, so a replay that finds **its own** record is reported as the success it was, while a genuine second refund — including after a process restart, which generates a new token — still raises. Reproduced first with fault injection that lets the `EVAL` reach Redis and commit before dropping the reply; I independently confirmed the new regressions fail against the pre-fix backends and pass with them.

## Floor kept at 5.2.1 deliberately

Pre-7 clients annotate `eval()`'s variadic arguments as `str` while the backend passes the ints and floats Redis accepts, so type-checking the source against a 5.x/6.x client reports four argument-type errors — with all suites passing against a live server on those same versions. Raising the floor to silence a typing artifact would drop working clients, so the floor stays and the nuance is documented for contributors in `DEVELOPMENT.md`.

Gates: 2068 unit/conformance/lint, 267 integration/multiprocess, ruff + format + mypy clean.